### PR TITLE
HAMSTR-543: Deep-link to Chat

### DIFF
--- a/chat-client/assets/js/listeners.js
+++ b/chat-client/assets/js/listeners.js
@@ -21,28 +21,33 @@ export class listeners {
             let recipient = params.target;
             let orderId = params.order;
 
-            if (!$('#users').hasClass('showing')) {
-                $('#users').addClass('showing');
-            }
-            const target = $(
-                'tr.user[data-id="YZKBhoCAGtJostcd"][data-name="' +
+            setTimeout(() => {
+                if (!$('#users').hasClass('showing')) {
+                    $('#users').addClass('showing');
+                }
+
+                const user = app.userForName(recipient);
+
+                const target = $(
+                    `tr.user[data-id="${user?.id ?? ''}"][data-name="' +
                     recipient +
-                    '"]'
-            );
+                    '"]`
+                );
 
-            let name = recipient;
+                let name = recipient;
 
-            let puny = `${app.ui.toUnicode(name)}/`;
-            $(`.popover[data-name=newConversation] input[name=domain]`).val(
-                puny
-            );
-            app.ui.popover('newConversation');
-            app.ui.enableTarget(target);
+                let puny = `${app.ui.toUnicode(name)}/`;
+                $(`.popover[data-name=newConversation] input[name=domain]`).val(
+                    puny
+                );
+                app.ui.popover('newConversation');
+                app.ui.enableTarget(target);
 
-            if (orderId?.length) {
-                const textbox = $('input[name="message"]');
-                textbox.val('Order: ' + orderId);
-            }
+                if (orderId?.length) {
+                    const textbox = $('input[name="message"]');
+                    textbox.val('Order: ' + orderId);
+                }
+            }, 1000);
         });
 
         $(window).on('focus', (e) => {
@@ -533,7 +538,6 @@ export class listeners {
                     break;
 
                 case 'newConversationWith':
-                    alert(target.id);
                     id = target.closest('.contextMenu').data('id');
                     name = app.userForID(id).domain;
                     let puny = `${app.ui.toUnicode(name)}/`;

--- a/chat-client/assets/js/listeners.js
+++ b/chat-client/assets/js/listeners.js
@@ -1,1106 +1,1255 @@
 export class listeners {
-	constructor(app) {
-		this.gifTimer;
-		this.lastGifSearch = 0;
-
-		this.longPress = 0;
-		this.longPressTimer;
-
-		// Test mode initialization
-		if (window.TEST_MODE) {
-			this.initializeTestMode(app);
-		}
-
-		$(window).on("focus", e => {
-			app.isActive = true;
-			app.ui.markUnread(app.conversation, false);
-		});
-
-		$(document).on("mouseenter", e => {
-		    app.isActive = true;
-		    app.ui.markUnread(app.conversation, false);
-		});
-
-		$(window).on("blur", e => {
-			app.isActive = false;
-		});
-
-		$(document).on("mouseleave", e => {
-		    app.isActive = false;
-		});
-
-		$(document).on("keydown", e => {
-			if (app.isKey(e, 27)) {
-				e.preventDefault();
-				
-				if (app.ui.undoProfileIfNeeded()) {
-					return;
-				}
-
-				if (app.ui.removeReplyingIfNeeded()) {
-					return;
-				}
-
-				if (app.ui.removePopoverIfNeeded()) {
-					return;
-				}
-			}
-
-			app.ui.preventTabIfNeeded(e);
-			app.ui.focusInputIfNeeded(e);
-		});
-
-		$("html").on("click", "#blackout", (e) => {
-			if (!this.longPress) {
-				app.ui.close();
-			}
-		});
-
-		$("html").on("click", "#closeMenu", () => {
-			app.ui.closeMenusIfNeeded();
-		});
-
-		$("html").on("click", "#conversations .tabs .tab", e => {
-			app.tab = $(e.target).data("tab");
-			app.ui.setConversationTab();
-		});
-
-		$("html").on("change", ".header .domains select", e => {
-			app.typing = false;
-
-			let domain = $(e.target).val();
-
-			if (domain == "manageDomains") {
-				app.ui.openURL("/id");
-			}
-			else {
-				app.changeDomain(domain);
-			}
-		});
-
-		$("html").on("click", "#conversations tr", e => {
-			app.typing = false;
-
-			let row = e.target.closest("tr");
-			let conversation = $(row).data("id");
-			
-			if (conversation == app.conversation || app.loadingMessages) {
-				app.ui.closeMenusIfNeeded();
-				return;
-			}
-
-			app.changeConversation(conversation);
-			localStorage.setItem("conversation", conversation);
-		});
-
-		$("#messageHolder").on("scroll", e => {
-			this.longPress = 0;
-			clearTimeout(this.longPressTimer);
-
-			let messageHolder = $(e.target);
-			if (app.loadingMessages) {
-				return;
-			}
-
-			let height = messageHolder.outerHeight();
-			let scrollTop = messageHolder[0].scrollTop;
-			let scrollHeight = messageHolder[0].scrollHeight - messageHolder.height();
-
-			if ((scrollHeight - height) == 0) {
-				return;
-			}
-
-			let calc = Math.floor(scrollHeight + scrollTop);
-			if (calc <= 1) {
-				let firstMessage = $("#messages > .messageRow[data-id]").first();
-				let firstMessageID = firstMessage.data("id");
-				if (firstMessageID) {
-					let options = {
-						before: firstMessageID
-					}
-					app.getMessages(options);
-				}
-			}
-			else if (calc == scrollHeight) {
-				app.ui.fetchNewMessages();
-			}
-		});
-
-		$("html").on("keydown", "textarea#message", e => {
-			let target = $(e.target);
-
-			let key = app.key(e);
-
-			if ($("#completions.shown").length) {
-				switch (key) {
-					case 38:
-					case 40:
-						e.preventDefault();
-						break;
-
-					case 9:
-					case 13:
-						e.preventDefault();
-						$("#completions tr.active").click();
-						return;
-				}
-			}
-
-			switch (key) {
-				case 9:
-					app.ui.tabComplete();
-					break;
-					
-				case 38:
-				case 40:
-				case 27:
-					return;
-			}
-
-			if (target.val() && target.val()[0] !== "/" && e.key.length == 1) {
-				app.lastTyped = app.time();
-			}
-
-			if (app.isKey(e, 13) && !e.shiftKey) {
-				e.preventDefault();
-
-				let data;
-				let attachments = $("#attachments .attachment");
-				if (attachments.find(".uploading").length) {
-					return;
-				}
-
-				$.each(attachments, (k, attachment) => {
-					let id = $(attachment).data("id");
-					data = {
-						hnschat: 1,
-						attachment: id
-					};
-					app.sendMessage(app.conversation, JSON.stringify(data));
-				});
-
-				let value = target.val().trim();
-				app.ui.clear("input");
-				$("#attachments").empty();
-				app.ui.showOrHideAttachments();
-
-				let replaced = app.replaceCompletions(value);
-				if (replaced.length) {
-					if (replaced[0] == "/") {
-						replaced = replaced.substring(1);
-						let split = replaced.split(" ");
-						let command = split.shift();
-						let rest = split.join(" ");
-
-						switch (command) {
-							case "me":
-								data = {
-									hnschat: 1,
-									action: rest
-								};
-								app.sendMessage(app.conversation, JSON.stringify(data));
-								break;
-
-							case "shrug":
-								data = {
-									hnschat: 1,
-									message: "¯\\_(ツ)_/¯"
-								};
-								app.sendMessage(app.conversation, JSON.stringify(data));
-								break;
-
-							case "fancy":
-								data = {
-									hnschat: 1,
-									message: rest,
-									style: command
-								};
-								app.sendMessage(app.conversation, JSON.stringify(data));
-								break;
-
-							case "confetti":
-								data = {
-									hnschat: 1,
-									message: rest,
-									effect: command
-								};
-								app.sendMessage(app.conversation, JSON.stringify(data));
-								break;
-
-							case "slap":
-								data = {
-									hnschat: 1,
-									action: `slaps ${rest} around a bit with a large trout`
-								};
-								app.sendMessage(app.conversation, JSON.stringify(data));
-								break;
-
-							default:
-								break;
-						}
-					}
-					else {
-						data = {
-							hnschat: 1,
-							message: replaced
-						};
-						app.sendMessage(app.conversation, JSON.stringify(data));
-					}
-				}
-			}
-
-			app.ui.sizeInput();
-		});
-
-		$("html").on("input paste keyup focus click", "textarea#message", e => {
-			let key = app.key(e);
-
-			switch (key) {
-				case 13:
-					return;
-
-				case 27:
-					app.ui.close();
-					return;
-
-				case 38:
-				case 40:
-					e.preventDefault();
-					app.ui.updateSelectedCompletion(key);
-					return;
-			}
-
-			switch (key) {
-				case 16:
-				case 17:
-				case 18:
-				case 20:
-				case 91:
-				case 93:
-					break;
-
-				default:
-					app.ui.updateCompletions();
-					break;
-			}
-			
-			app.ui.sizeInput();
-		});
-
-		$("html").on("click", "#completions tr", e => {
-			let target = $(e.target).closest("tr");
-
-			$("#completions tr").removeClass("active");
-			target.addClass("active");
-
-			let completion = target.find(".title").html();
-			if (target.hasClass("user")) {
-				completion = `@${completion}/`;
-			}
-			else {
-				completion = `#${completion}`;
-			}
-
-			let input = $("textarea#message");
-			let text = input.val();
-			let words = text.split(" ");
-			let position = input[0].selectionStart;
-			let word = app.ui.wordForPosition(text, position);
-			let before = words[word];
-			words[word] = `${completion} `;
-
-			let newPosition = 0;
-			for (let i = 0; i < words.length; i++) {
-				newPosition += words[i].length;
-
-				if (i == word) {
-					newPosition += i;
-					break;
-				}
-			}
-
-			let replaced = words.join(" ");
-			input.val(replaced);
-			app.ui.setCaretPosition(input[0], newPosition);
-			app.ui.close();
-		});
-
-		$("html").on("click", ".action, .button, .link", e => {
-			let target = $(e.target);
-
-			if ($("body").hasClass("touching")) {
-				return;
-			}
-
-			target.parent().find(".response").html('');
-			target.parent().parent().find(".response").html('');
-
-			if (target.hasClass("disabled")) {
-				return;
-			}
-			target.addClass("disabled");
-
-			let action = target.data("action");
-
-			var sender,context;
-			var data;
-			var id,domain,sld,tld,message,name;
-
-			switch (action) {
-				case "scanQR":
-					if (window.TEST_MODE) {
-						app.ui.enableTarget(target);
-						return;
-					}
-					app.ui.scanQR();
-					app.ui.popover("qr");
-					app.ui.enableTarget(target);
-					break;
-
-				case "reply":
-					context = target.closest(".contextMenu");
-					if (context.length) {
-						app.replying = {
-							message: context.data("id"),
-							sender: context.data("sender"),
-						}
-					}
-					else {
-						app.replying = {
-							message: target.closest(".messageRow").data("id"),
-							sender: target.closest(".messageRow").data("sender"),
-						}
-					}
-
-					app.ui.close();
-					app.ui.updateReplying();
-					$(".input #message").focus();
-					app.ui.enableTarget(target);
-					break;
-
-				case "removeReply":
-					app.replying = null;
-					app.ui.updateReplying();
-					app.ui.enableTarget(target);
-					break;
-
-				case "donate":
-				case "syncSession":
-					app.ui.popover(action);
-					app.ui.enableTarget(target);
-					break;
-
-				case "replayEffect":
-					app.ui.handleEffect(target.data("effect")).then(() => {
-						app.ui.enableTarget(target);
-					});
-					break;
-
-				case "settings":
-					$(".popover[data-name=settings] input[name=bubbleBackground]").val(app.ui.css.getPropertyValue("--bubbleBackground").trim());
-					$(".popover[data-name=settings] input[name=bubbleSelfBackground]").val(app.ui.css.getPropertyValue("--bubbleSelfBackground").trim());
-					$(".popover[data-name=settings] input[name=bubbleMentionBackground]").val(app.ui.css.getPropertyValue("--bubbleMentionBackground").trim());
-					if (app.settings.chatDisplayMode) {
-						$(".popover[data-name=settings] select[name=chatDisplayMode]").val(app.settings.chatDisplayMode);
-					}
-					app.ui.popover(action);
-					app.ui.enableTarget(target);
-					break;
-
-				case "docs":
-					app.ui.openURL("https://docs.hns.chat", { newTab: true });
-					app.ui.enableTarget(target);
-					break;
-
-				case "pay":
-					let conversation = app.pmForID(app.conversation);
-					app.ws.send(`GETADDRESS ${app.otherUser(conversation.users)}`);
-					app.ui.popover(action);
-					app.ui.enableTarget(target);
-					break;
-
-				case "sendPayment":
-					let address = target.parent().find("input[name=address]").val();
-					let amount = target.parent().find("input[name=hns]").val().replace(/[^0-9.]/g, '');
-					app.sendPayment(address, amount).then(r => {
-						if (r.message) {
-							let data = {
-								type: action,
-								message: `Error: ${r.message}`
-							}
-							app.ui.errorResponse(data);
-						}
-						else if (r.hash) {
-							let data = {
-								hnschat: 1,
-								payment: r.hash,
-								amount: amount
-							}
-							app.sendMessage(app.conversation, JSON.stringify(data));
-							app.ui.close();
-						}
-						app.ui.enableTarget(target);
-					});
-					break;
-
-				case "newConversation":
-					if (!app.userForID(app.domain).locked) {
-						app.ui.popover(action);
-					}
-					app.ui.enableTarget(target);
-					break;
-
-				case "newConversationWith":
-					id = target.closest(".contextMenu").data("id");
-					name = app.userForID(id).domain;
-					let puny = `${app.ui.toUnicode(name)}/`;
-					$(`.popover[data-name=newConversation] input[name=domain]`).val(puny);
-					app.ui.popover("newConversation");
-					app.ui.enableTarget(target);
-					break;
-
-				case "mentionUser":
-					id = target.closest(".contextMenu").data("id");
-					name = `@${app.userForID(id).domain}/`;
-					let text = $("#message").val();
-					text = `${text}${name} `;
-					$("#message").val(text);
-					app.ui.close();
-					app.ui.closeMenusIfNeeded();
-					app.ui.enableTarget(target);
-					$("#message").focus();
-					break;
-
-				case "slapUser":
-					id = target.closest(".contextMenu").data("id");
-					name = `@${app.userForID(id).domain}/`;
-					message = app.replaceCompletions(`slaps ${name} around a bit with a large trout`);
-					data = {
-						hnschat: 1,
-						action: message
-					};
-					app.sendMessage(app.conversation, JSON.stringify(data));
-					app.ui.close();
-					app.ui.closeMenusIfNeeded();
-					app.ui.enableTarget(target);
-					$("#message").focus();
-					break;
-
-				case "switchConversation":
-					id = target.closest(".contextMenu").data("id");
-					$(`#conversations tr[data-id=${id}]`).click();
-					app.ui.close();
-					app.ui.enableTarget(target);
-					break;
-
-				case "startConversation":
-					domain = target.parent().find("input[name=domain]").val().trim();
-					domain = app.rtrim(domain, "/").trim();
-					domain = app.userForName(domain).domain;
-					message = target.parent().find("input[name=message]").val();
-
-					if (message.length) {
-						app.queued.push({
-							domain: domain,
-							message: message
-						});
-
-						data = {
-							domain: domain
-						}
-						app.ws.send(`PM ${JSON.stringify(data)}`);
-					}
-					else {
-						data = {
-							type: action,
-							message: "Please enter a message.",
-						}
-						app.ui.errorResponse(data);
-					}
-					app.ui.enableTarget(target);
-					break;
-
-				case "clipboard":
-					app.ui.copyToClipboard(target);
-					app.ui.enableTarget(target);
-					break;
-
-				case "gifs":
-				case "emojis":
-					context = target.closest(".contextMenu");
-					if (context.length) {
-						sender = context.data("id");
-					}
-					else {
-						sender = target.closest(".messageRow").data("id");
-					}
-					
-					app.ui.setupReactView(e, sender);
-					app.ui.popover("react");
-					app.ui.enableTarget(target);
-					break;
-
-				case "createSLD":
-					e.newTab = true;
-					app.ui.openURL("/id");
-					app.ui.enableTarget(target);
-					break;
-
-				case "purchaseSLD":
-					e.newTab = true;
-					app.ui.openURL(target.data("link"), e);
-					app.ui.enableTarget(target);
-					break;
-
-				case "switchName":
-					domain = target.data("id");
-					app.changeDomain(domain);
-					break;
-
-				case "newDomain":
-					if (window.TEST_MODE) {
-						app.ui.showSection("addDomain");
-						app.ui.enableTarget(target);
-						return;
-					}
-					app.ui.showSection("addDomain");
-					app.ui.enableTarget(target);
-					break;
-
-				case "addDomain":
-					if (window.TEST_MODE) {
-						app.ui.showSection("verifyOptions");
-						app.ui.enableTarget(target);
-						return;
-					}
-					app.varo.auth().then(auth => {
-						if (auth.success) {
-							let data = {
-								request: auth.data.request
-							};
-							app.ws.send(`ADDDOMAIN ${JSON.stringify(data)}`);
-						}
-						app.ui.enableTarget(target);
-					});
-					break;
-
-				case "verifyDomain":
-					if (window.TEST_MODE) {
-						app.ui.showSection("startChatting");
-						app.ui.enableTarget(target);
-						return;
-					}
-					app.varo.auth().then(auth => {
-						if (auth.success) {
-							let data = {
-								id: target.closest(".domain").data("id"),
-								request: auth.data.request
-							};
-							app.ws.send(`VERIFYDOMAIN ${JSON.stringify(data)}`);
-						}
-						app.ui.enableTarget(target);
-					});
-					break;
-
-				case "addSLD":
-					if (window.TEST_MODE) {
-						app.ui.showSection("verifyOptions");
-						app.ui.enableTarget(target);
-						return;
-					}
-					sld = target.parent().find("input[name=sld]").val();
-					tld = target.parent().find("select[name=tld]").val();
-					data = {
-						sld: sld,
-						tld: tld
-					}
-					app.ws.send(`ADDSLD ${JSON.stringify(data)}`);
-					break;
-
-				case "deleteDomain":
-					if (window.TEST_MODE) {
-						app.ui.showSection("manageDomains");
-						app.ui.enableTarget(target);
-						return;
-					}
-					domain = target.closest(".domain").data("id");
-					data = {
-						id: domain
-					};
-					app.ws.send(`DELETEDOMAIN ${JSON.stringify(data)}`);
-					break;
-
-				case "manageDomains":
-					if (window.TEST_MODE) {
-						app.ui.showSection("manageDomains");
-						app.ui.enableTarget(target);
-						return;
-					}
-					app.ui.showSection("manageDomains");
-					app.ui.enableTarget(target);
-					break;
-
-				case "deleteMessage":
-					message = target.closest(".contextMenu").data("id");
-					data = {
-						id: message
-					}
-					app.ws.send(`DELETEMESSAGE ${JSON.stringify(data)}`);
-					app.ui.close();
-					app.ui.enableTarget(target);
-					break;
-
-				case "pinMessage":
-					message = target.closest(".contextMenu").data("id");
-					data = {
-						conversation: app.conversation,
-						id: message
-					}
-					app.ws.send(`PINMESSAGE ${JSON.stringify(data)}`);
-					app.ui.close();
-					app.ui.enableTarget(target);
-					break;
-
-				case "searchUsers":
-					if (target.hasClass("close")) {
-						app.ui.searchUsers(false);
-					}
-					else {
-						app.ui.searchUsers(true);
-					}
-					app.ui.enableTarget(target);
-					break;
-
-				case "saveSettings":
-					let fields = $(".popover[data-name=settings] .local");
-					$.each(fields, (k, field) => {
-						let name = $(field).attr("name");
-						let val = $(field).val();
-						app.settings[name] = val;
-					});
-					localStorage.setItem("settings", JSON.stringify(app.settings));
-					app.loadSettings();
-
-					data = {
-						action: "saveSettings",
-						domain: app.domain,
-						settings: {}
-					}
-
-					fields = $(".popover[data-name=settings] input.remote");
-					$.each(fields, (k, field) => {
-						let name = $(field).attr("name");
-						let val = $(field).val();
-						data.settings[name] = val;
-					});
-
-					data.settings = JSON.stringify(data.settings);
-
-					app.api(data).then(r => {
-						if (r.success) {
-							if (r.avatar) {
-								delete app.avatars[app.domain];
-								app.userForID(app.domain).avatar = r.avatar;
-								$(`.favicon.loaded[data-id=${app.domain}]`).removeClass("loaded");
-								app.ui.updateAvatars();
-								app.ws.send(`SAVEDSETTINGS`);
-							}
-							app.ui.close();
-						}
-						else {
-							data = {
-								type: action,
-								message: r.message,
-							}
-							app.ui.errorResponse(data);
-						}
-
-						app.ui.enableTarget(target);
-					});
-					break;
-
-				case "file":
-					$("#file")[0].click();
-					app.ui.enableTarget(target);
-					break;
-
-				case "removeAttachment":
-					let attachment = target.parent().parent();
-					attachment.remove();
-					app.ui.showOrHideAttachments();
-					data = {
-						id: attachment.data("id")
-					}
-					app.ws.send(`DELETEATTACHMENT ${JSON.stringify(data)}`);
-					break;
-
-				case "editProfile":
-					app.ui.editProfile();
-					app.ui.enableTarget(target);
-					break;
-
-				case "saveProfile":
-					app.ui.saveProfile();
-					app.ui.enableTarget(target);
-					break;
-
-				case "undoProfile":
-					app.ui.undoProfile();
-					app.ui.enableTarget(target);
-					break;
-
-				case "close":
-					app.ui.close();
-					app.ui.enableTarget(target);
-					break;
-
-				case "reload":
-					window.location.reload();
-					break;
-
-				case "startVideo":
-				case "joinVideo":
-					app.channelForID(app.conversation).watching = true;
-					data = {
-						conversation: app.conversation
-					}
-					if (app.channelForID(app.conversation).video) {
-						app.ws.send(`JOINVIDEO ${JSON.stringify(data)}`);
-					}
-					else {
-						app.ws.send(`STARTVIDEO ${JSON.stringify(data)}`);
-					}
-					app.ui.enableTarget(target);
-					break;
-
-				case "inviteVideo":
-					id = target.closest(".contextMenu").data("id");
-
-					data = {
-						conversation: app.conversation,
-						user: id
-					}
-					app.ws.send(`INVITEVIDEO ${JSON.stringify(data)}`);
-					app.ui.close();
-					app.ui.closeMenusIfNeeded();
-					app.ui.enableTarget(target);
-					break;
-
-				case "leaveVideo":
-					if (Object.keys(app.channelForID(app.conversation).videoUsers).includes(app.domain)) {
-						app.stream.unpublish();
-					}
-					else {
-						app.channelForID(app.conversation).watching = false;
-						app.stream.close();
-						app.ui.showVideoIfNeeded();
-					}
-					data = {
-						conversation: app.conversation
-					}
-					app.ws.send(`LEAVEVIDEO ${JSON.stringify(data)}`);
-					app.ui.enableTarget(target);
-					break;
-
-				case "endVideo":
-					if (Object.keys(app.channelForID(app.conversation).videoUsers).includes(app.domain)) {
-						app.stream.unpublish();
-					}
-					data = {
-						conversation: app.conversation
-					}
-					app.ws.send(`ENDVIDEO ${JSON.stringify(data)}`);
-					app.ui.enableTarget(target);
-					break;
-
-				case "toggleVideo":
-					app.stream.mute("video", !$(".controls .button[data-action=toggleVideo]").hasClass("muted"));
-					data = {
-						conversation: app.conversation
-					}
-					app.ws.send(`MUTEVIDEO ${JSON.stringify(data)}`);
-					app.ui.enableTarget(target);
-					break;
-
-				case "toggleAudio":
-					app.stream.mute("audio", !$(".controls .button[data-action=toggleAudio]").hasClass("muted"));
-					data = {
-						conversation: app.conversation
-					}
-					app.ws.send(`MUTEAUDIO ${JSON.stringify(data)}`);
-					app.ui.enableTarget(target);
-					break;
-
-				case "toggleScreen":
-					app.stream.toggleScreen();
-					app.ui.enableTarget(target);
-					break;
-
-				case "viewVideo":
-					data = {
-						conversation: app.conversation
-					}
-					app.ws.send(`VIEWVIDEO ${JSON.stringify(data)}`);
-					app.ui.enableTarget(target);
-					break;
-
-				default:
-					app.ui.enableTarget(target);
-					break;
-			}
-		});
-
-		$("html").on("keyup", ".popover[data-name=react] input", e => {
-			if (app.isKey(e, 27)) {
-				e.preventDefault();
-				return;
-			}
-
-			let query = $(e.currentTarget).val().replace(/[^a-zA-Z0-9]/gi, '').toLowerCase();
-			if (query) {
-				let emo = $(".popover[data-name=react] .section:not([data-name=Search]) .emoji");
-				let matches = emo.filter((k, em) => {
-					let aliases = $(em).data("aliases");
-
-					$.each(aliases, (k, alias) => {
-						aliases[k] = alias.replace(/[^a-zA-Z0-9]/gi, '').toLowerCase();
-					});
-
-					return aliases.join("|").includes(query);
-				});
-
-				$(".popover[data-name=react] .grid .section[data-name=Search] .emojis").empty();
-				$.each(matches, (k, match) => {
-					let clone = match.cloneNode(true);
-					$(".popover[data-name=react] .grid .section[data-name=Search] .emojis").append(clone);
-				});
-
-				$(".popover[data-name=react] .grid .section").addClass("hidden");
-				$(".popover[data-name=react] .grid .section[data-name=Search]").removeClass("hidden");
-			}
-			else {
-				$(".popover[data-name=react] .grid .section").removeClass("hidden");
-				$(".popover[data-name=react] .grid .section[data-name=Search]").addClass("hidden");
-			}
-		});
-
-		$("html").on("click", ".popover[data-name=react] .emoji", e => {
-			let sender = $(".popover[data-name=react]").data("sender");
-			let emoji = $(e.currentTarget);
-			let em = emoji.html();
-
-			if (sender.length) {
-				let reacting = $(".messageRow .hover.visible").closest(".messageRow").data("id");
-				app.ui.close();
-				let data = {
-					conversation: app.conversation,
-					message: reacting,
-					reaction: em
-				};
-				app.ws.send(`REACT ${JSON.stringify(data)}`);
-			}
-			else {
-				let field = $(".input #message");
-				let current = field.val();
-				let split = Array.from(current);
-				let position = field[0].selectionStart;
-				let added = app.replaceRange(current, position, position, em);
-				field.val(added);
-				app.ui.close();
-				$(".input #message").focus();
-				app.ui.setCaretPosition(field[0], position + em.length);
-			}
-		});
-
-		$("html").on("click", ".reaction", e => {
-			let target = $(e.currentTarget);
-			let reacting = target.closest(".messageRow").data("id");
-			let em = target.data("reaction");
-
-			let data = {
-				conversation: app.conversation,
-				message: reacting,
-				reaction: em
-			};
-			app.ws.send(`REACT ${JSON.stringify(data)}`);
-		});
-
-		$("html").on("click", "#react .tab", e => {
-			let target = $(e.target);
-			let name = target.data("name");
-			app.ui.switchReactTab(name);
-		});
-
-		$("html").on("click", "#react .category", e => {
-			let target = $(e.target);
-			let term = target.data("term");
-			$("#react input[name=searchGifs]").val(term);
-			app.ui.searchGifs(term);
-		});
-
-		$("html").on("input", "#react input[name=searchGifs]", e => {
-			let target = $(e.target);
-			let value = target.val().trim();
-			
-			clearInterval(this.gifTimer);
-			this.lastGifSearch = app.time();
-			this.gifTimer = setInterval(() => {
-				let timeSince = app.time() - this.lastGifSearch;
-				if (timeSince >= 1) {
-					app.ui.searchGifs(value);
-					clearInterval(this.gifTimer);
-				}
-			}, 100);
-		});
-
-		$("html").on("click", "#react .gif", e => {
-			let target = $(e.target);
-			let gif = target.data("full");
-
-			let data = {
-				hnschat: 1,
-				attachment: gif
-			};
-			app.sendMessage(app.conversation, JSON.stringify(data));
-			app.ui.close();
-		});
-
-		$("html").on("click", e => {
-			let target = $(e.currentTarget);
-		});
-
-		$("html").on("click", "#users .user, .messageRow .user, .messageRow .favicon, .inline.nick, .header .favicon, .inline.channel, .cam table .user, .screen table .user, #videoInfo .avatar > div", e => {
-			let target = $(e.currentTarget);
-
-			if (!app.userForID(app.domain).locked) {
-				app.ui.handleRightClick(e, target);
-			}
-		});
-
-		$("html").on("input paste keydown focus click", ".contextMenu[data-name=userContext] .bioHolder .bio", e => {
-			app.ui.updateBioLimit(e);
-		});
-
-		$(window).on("contextmenu", e => {
-			let target = $(e.target);
-
-			if (["INPUT", "TEXTAREA", "A"].includes(target.prop("tagName")) || target.hasClass("body") || (target.hasClass("inline") && !(target.hasClass("nick") || target.hasClass("channel")))) {
-				return;
-			}
-			else {
-				e.preventDefault();
-
-				app.ui.handleRightClick(e, target);
-			}
-		});
-
-		$("html").on("touchstart", ".messageRow", e => {
-			let target = $(e.target);
-			if (!(target.hasClass("messageRow") || target.hasClass("message") || target.hasClass("body") || target.hasClass("main") || target.hasClass("msg") || target.hasClass("hover"))) {
-				return;
-			}
-
-			$("body").addClass("touching");
-			this.longPress = e.timeStamp;
-			this.longPressTimer = setTimeout(() => {
-				app.ui.handleRightClick(e, target);
-			}, 500);
-		});
-
-		$("html").on("touchcancel", ".messageRow", e => {
-			$("body").removeClass("touching");
-			this.longPress = 0;
-			clearTimeout(this.longPressTimer);
-		});
-
-		$("html").on("touchend", ".messageRow", e => {
-			if ($("#blackout").hasClass("shown")) {
-				setTimeout(() => {
-					this.longPress = 0;
-					clearTimeout(this.longPressTimer);
-					$("body").removeClass("touching");
-				}, 500);
-			}
-
-			let duration = e.timeStamp - this.longPress;
-			if (duration < 500) {
-				this.longPress = 0;
-				clearTimeout(this.longPressTimer);
-				$("body").removeClass("touching");
-			}
-		});
-
-		$("html").on("click", ".header .icon.menu", e => {
-			if ($("#conversations").hasClass("showing")) {
-				$("body").removeClass("menu");
-				$("#conversations").removeClass("showing");
-			}
-			else {
-				if ($("#users").hasClass("showing")) {
-					$("body").removeClass("menu");
-					$("#users").removeClass("showing")
-				}
-				$("body").addClass("menu");
-				$("#conversations").addClass("showing");
-			}
-		});
-
-		$("html").on("click", ".header .icon.users", e => {
-			if ($("#holder[data-type=pms]").length) {
-				return;
-			}
-
-			if ($("#users").hasClass("showing")) {
-				$("body").removeClass("menu");
-				$("#users").removeClass("showing");
-			}
-			else {
-				if ($("#conversations").hasClass("showing")) {
-					$("body").removeClass("menu");
-					$("#conversations").removeClass("showing")
-				}
-				$("body").addClass("menu");
-				$("#users").addClass("showing");
-			}
-		});
-
-		$("html").on("keyup", "input", e => {
-			if (app.isKey(e, 13)) {
-				let target = $(e.target);
-				let submit = target.parent().find(".button").last();
-				if (!submit.length) {
-					submit = target.closest(".section").find(".button").last();
-				}
-				submit.click();
-			}
-		});
-
-		$("html").on("keydown", "input[name=hns]", e => {
-			let key = e.key;
-			let keyCode = app.key(e);
-			let match = key.match(/[a-z ]/g);
-			if (match && !(e.shiftKey || e.metaKey || e.ctrlKey) && !(keyCode >= 37 && keyCode <= 40)) {
-				e.preventDefault();
-			}
-		});
-
-		$("html").on("keyup", "#users input[name=search]", e => {
-			if (app.isKey(e, 27)) {
-				app.ui.searchUsers(false);
-			}
-			else {
-				let target = $(e.target);
-				let value = target.val().trim();
-				app.ui.queryUsers(value);
-			}
-		});
-
-		$("html").on("change", "#file", e => {
-			let file = $(e.currentTarget)[0].files[0];
-
-			if (file) {
-				let url = URL.createObjectURL(file);
-				let attachment = $(`
+    constructor(app) {
+        this.gifTimer;
+        this.lastGifSearch = 0;
+
+        this.longPress = 0;
+        this.longPressTimer;
+
+        // Test mode initialization
+        if (window.TEST_MODE) {
+            this.initializeTestMode(app);
+        }
+
+        $(document).ready((e) => {
+            const params = new Proxy(
+                new URLSearchParams(window.location.search),
+                {
+                    get: (searchParams, prop) => searchParams.get(prop),
+                }
+            );
+            let recipient = params.target;
+            let orderId = params.order;
+
+            if (!$('#users').hasClass('showing')) {
+                $('#users').addClass('showing');
+            }
+            const target = $(
+                'tr.user[data-id="YZKBhoCAGtJostcd"][data-name="' +
+                    recipient +
+                    '"]'
+            );
+
+            let name = recipient;
+
+            let puny = `${app.ui.toUnicode(name)}/`;
+            $(`.popover[data-name=newConversation] input[name=domain]`).val(
+                puny
+            );
+            app.ui.popover('newConversation');
+            app.ui.enableTarget(target);
+
+            if (orderId?.length) {
+                const textbox = $('input[name="message"]');
+                textbox.val('Order: ' + orderId);
+            }
+        });
+
+        $(window).on('focus', (e) => {
+            app.isActive = true;
+            app.ui.markUnread(app.conversation, false);
+        });
+
+        $(document).on('mouseenter', (e) => {
+            app.isActive = true;
+            app.ui.markUnread(app.conversation, false);
+        });
+
+        $(window).on('blur', (e) => {
+            app.isActive = false;
+        });
+
+        $(document).on('mouseleave', (e) => {
+            app.isActive = false;
+        });
+
+        $(document).on('keydown', (e) => {
+            if (app.isKey(e, 27)) {
+                e.preventDefault();
+
+                if (app.ui.undoProfileIfNeeded()) {
+                    return;
+                }
+
+                if (app.ui.removeReplyingIfNeeded()) {
+                    return;
+                }
+
+                if (app.ui.removePopoverIfNeeded()) {
+                    return;
+                }
+            }
+
+            app.ui.preventTabIfNeeded(e);
+            app.ui.focusInputIfNeeded(e);
+        });
+
+        $('html').on('click', '#blackout', (e) => {
+            if (!this.longPress) {
+                app.ui.close();
+            }
+        });
+
+        $('html').on('click', '#closeMenu', () => {
+            app.ui.closeMenusIfNeeded();
+        });
+
+        $('html').on('click', '#conversations .tabs .tab', (e) => {
+            app.tab = $(e.target).data('tab');
+            app.ui.setConversationTab();
+        });
+
+        $('html').on('change', '.header .domains select', (e) => {
+            app.typing = false;
+
+            let domain = $(e.target).val();
+
+            if (domain == 'manageDomains') {
+                app.ui.openURL('/id');
+            } else {
+                app.changeDomain(domain);
+            }
+        });
+
+        $('html').on('click', '#conversations tr', (e) => {
+            app.typing = false;
+
+            let row = e.target.closest('tr');
+            let conversation = $(row).data('id');
+
+            if (conversation == app.conversation || app.loadingMessages) {
+                app.ui.closeMenusIfNeeded();
+                return;
+            }
+
+            app.changeConversation(conversation);
+            localStorage.setItem('conversation', conversation);
+        });
+
+        $('#messageHolder').on('scroll', (e) => {
+            this.longPress = 0;
+            clearTimeout(this.longPressTimer);
+
+            let messageHolder = $(e.target);
+            if (app.loadingMessages) {
+                return;
+            }
+
+            let height = messageHolder.outerHeight();
+            let scrollTop = messageHolder[0].scrollTop;
+            let scrollHeight =
+                messageHolder[0].scrollHeight - messageHolder.height();
+
+            if (scrollHeight - height == 0) {
+                return;
+            }
+
+            let calc = Math.floor(scrollHeight + scrollTop);
+            if (calc <= 1) {
+                let firstMessage = $(
+                    '#messages > .messageRow[data-id]'
+                ).first();
+                let firstMessageID = firstMessage.data('id');
+                if (firstMessageID) {
+                    let options = {
+                        before: firstMessageID,
+                    };
+                    app.getMessages(options);
+                }
+            } else if (calc == scrollHeight) {
+                app.ui.fetchNewMessages();
+            }
+        });
+
+        $('html').on('keydown', 'textarea#message', (e) => {
+            let target = $(e.target);
+
+            let key = app.key(e);
+
+            if ($('#completions.shown').length) {
+                switch (key) {
+                    case 38:
+                    case 40:
+                        e.preventDefault();
+                        break;
+
+                    case 9:
+                    case 13:
+                        e.preventDefault();
+                        $('#completions tr.active').click();
+                        return;
+                }
+            }
+
+            switch (key) {
+                case 9:
+                    app.ui.tabComplete();
+                    break;
+
+                case 38:
+                case 40:
+                case 27:
+                    return;
+            }
+
+            if (target.val() && target.val()[0] !== '/' && e.key.length == 1) {
+                app.lastTyped = app.time();
+            }
+
+            if (app.isKey(e, 13) && !e.shiftKey) {
+                e.preventDefault();
+
+                let data;
+                let attachments = $('#attachments .attachment');
+                if (attachments.find('.uploading').length) {
+                    return;
+                }
+
+                $.each(attachments, (k, attachment) => {
+                    let id = $(attachment).data('id');
+                    data = {
+                        hnschat: 1,
+                        attachment: id,
+                    };
+                    app.sendMessage(app.conversation, JSON.stringify(data));
+                });
+
+                let value = target.val().trim();
+                app.ui.clear('input');
+                $('#attachments').empty();
+                app.ui.showOrHideAttachments();
+
+                let replaced = app.replaceCompletions(value);
+                if (replaced.length) {
+                    if (replaced[0] == '/') {
+                        replaced = replaced.substring(1);
+                        let split = replaced.split(' ');
+                        let command = split.shift();
+                        let rest = split.join(' ');
+
+                        switch (command) {
+                            case 'me':
+                                data = {
+                                    hnschat: 1,
+                                    action: rest,
+                                };
+                                app.sendMessage(
+                                    app.conversation,
+                                    JSON.stringify(data)
+                                );
+                                break;
+
+                            case 'shrug':
+                                data = {
+                                    hnschat: 1,
+                                    message: '¯\\_(ツ)_/¯',
+                                };
+                                app.sendMessage(
+                                    app.conversation,
+                                    JSON.stringify(data)
+                                );
+                                break;
+
+                            case 'fancy':
+                                data = {
+                                    hnschat: 1,
+                                    message: rest,
+                                    style: command,
+                                };
+                                app.sendMessage(
+                                    app.conversation,
+                                    JSON.stringify(data)
+                                );
+                                break;
+
+                            case 'confetti':
+                                data = {
+                                    hnschat: 1,
+                                    message: rest,
+                                    effect: command,
+                                };
+                                app.sendMessage(
+                                    app.conversation,
+                                    JSON.stringify(data)
+                                );
+                                break;
+
+                            case 'slap':
+                                data = {
+                                    hnschat: 1,
+                                    action: `slaps ${rest} around a bit with a large trout`,
+                                };
+                                app.sendMessage(
+                                    app.conversation,
+                                    JSON.stringify(data)
+                                );
+                                break;
+
+                            default:
+                                break;
+                        }
+                    } else {
+                        data = {
+                            hnschat: 1,
+                            message: replaced,
+                        };
+                        app.sendMessage(app.conversation, JSON.stringify(data));
+                    }
+                }
+            }
+
+            app.ui.sizeInput();
+        });
+
+        $('html').on(
+            'input paste keyup focus click',
+            'textarea#message',
+            (e) => {
+                let key = app.key(e);
+
+                switch (key) {
+                    case 13:
+                        return;
+
+                    case 27:
+                        app.ui.close();
+                        return;
+
+                    case 38:
+                    case 40:
+                        e.preventDefault();
+                        app.ui.updateSelectedCompletion(key);
+                        return;
+                }
+
+                switch (key) {
+                    case 16:
+                    case 17:
+                    case 18:
+                    case 20:
+                    case 91:
+                    case 93:
+                        break;
+
+                    default:
+                        app.ui.updateCompletions();
+                        break;
+                }
+
+                app.ui.sizeInput();
+            }
+        );
+
+        $('html').on('click', '#completions tr', (e) => {
+            let target = $(e.target).closest('tr');
+
+            $('#completions tr').removeClass('active');
+            target.addClass('active');
+
+            let completion = target.find('.title').html();
+            if (target.hasClass('user')) {
+                completion = `@${completion}/`;
+            } else {
+                completion = `#${completion}`;
+            }
+
+            let input = $('textarea#message');
+            let text = input.val();
+            let words = text.split(' ');
+            let position = input[0].selectionStart;
+            let word = app.ui.wordForPosition(text, position);
+            let before = words[word];
+            words[word] = `${completion} `;
+
+            let newPosition = 0;
+            for (let i = 0; i < words.length; i++) {
+                newPosition += words[i].length;
+
+                if (i == word) {
+                    newPosition += i;
+                    break;
+                }
+            }
+
+            let replaced = words.join(' ');
+            input.val(replaced);
+            app.ui.setCaretPosition(input[0], newPosition);
+            app.ui.close();
+        });
+
+        $('html').on('click', '.action, .button, .link', (e) => {
+            let target = $(e.target);
+
+            if ($('body').hasClass('touching')) {
+                return;
+            }
+
+            target.parent().find('.response').html('');
+            target.parent().parent().find('.response').html('');
+
+            if (target.hasClass('disabled')) {
+                return;
+            }
+            target.addClass('disabled');
+
+            let action = target.data('action');
+
+            var sender, context;
+            var data;
+            var id, domain, sld, tld, message, name;
+
+            switch (action) {
+                case 'scanQR':
+                    if (window.TEST_MODE) {
+                        app.ui.enableTarget(target);
+                        return;
+                    }
+                    app.ui.scanQR();
+                    app.ui.popover('qr');
+                    app.ui.enableTarget(target);
+                    break;
+
+                case 'reply':
+                    context = target.closest('.contextMenu');
+                    if (context.length) {
+                        app.replying = {
+                            message: context.data('id'),
+                            sender: context.data('sender'),
+                        };
+                    } else {
+                        app.replying = {
+                            message: target.closest('.messageRow').data('id'),
+                            sender: target
+                                .closest('.messageRow')
+                                .data('sender'),
+                        };
+                    }
+
+                    app.ui.close();
+                    app.ui.updateReplying();
+                    $('.input #message').focus();
+                    app.ui.enableTarget(target);
+                    break;
+
+                case 'removeReply':
+                    app.replying = null;
+                    app.ui.updateReplying();
+                    app.ui.enableTarget(target);
+                    break;
+
+                case 'donate':
+                case 'syncSession':
+                    app.ui.popover(action);
+                    app.ui.enableTarget(target);
+                    break;
+
+                case 'replayEffect':
+                    app.ui.handleEffect(target.data('effect')).then(() => {
+                        app.ui.enableTarget(target);
+                    });
+                    break;
+
+                case 'settings':
+                    $(
+                        '.popover[data-name=settings] input[name=bubbleBackground]'
+                    ).val(
+                        app.ui.css.getPropertyValue('--bubbleBackground').trim()
+                    );
+                    $(
+                        '.popover[data-name=settings] input[name=bubbleSelfBackground]'
+                    ).val(
+                        app.ui.css
+                            .getPropertyValue('--bubbleSelfBackground')
+                            .trim()
+                    );
+                    $(
+                        '.popover[data-name=settings] input[name=bubbleMentionBackground]'
+                    ).val(
+                        app.ui.css
+                            .getPropertyValue('--bubbleMentionBackground')
+                            .trim()
+                    );
+                    if (app.settings.chatDisplayMode) {
+                        $(
+                            '.popover[data-name=settings] select[name=chatDisplayMode]'
+                        ).val(app.settings.chatDisplayMode);
+                    }
+                    app.ui.popover(action);
+                    app.ui.enableTarget(target);
+                    break;
+
+                case 'docs':
+                    app.ui.openURL('https://docs.hns.chat', { newTab: true });
+                    app.ui.enableTarget(target);
+                    break;
+
+                case 'pay':
+                    let conversation = app.pmForID(app.conversation);
+                    app.ws.send(
+                        `GETADDRESS ${app.otherUser(conversation.users)}`
+                    );
+                    app.ui.popover(action);
+                    app.ui.enableTarget(target);
+                    break;
+
+                case 'sendPayment':
+                    let address = target
+                        .parent()
+                        .find('input[name=address]')
+                        .val();
+                    let amount = target
+                        .parent()
+                        .find('input[name=hns]')
+                        .val()
+                        .replace(/[^0-9.]/g, '');
+                    app.sendPayment(address, amount).then((r) => {
+                        if (r.message) {
+                            let data = {
+                                type: action,
+                                message: `Error: ${r.message}`,
+                            };
+                            app.ui.errorResponse(data);
+                        } else if (r.hash) {
+                            let data = {
+                                hnschat: 1,
+                                payment: r.hash,
+                                amount: amount,
+                            };
+                            app.sendMessage(
+                                app.conversation,
+                                JSON.stringify(data)
+                            );
+                            app.ui.close();
+                        }
+                        app.ui.enableTarget(target);
+                    });
+                    break;
+
+                case 'newConversation':
+                    if (!app.userForID(app.domain).locked) {
+                        app.ui.popover(action);
+                    }
+                    app.ui.enableTarget(target);
+                    break;
+
+                case 'newConversationWith':
+                    alert(target.id);
+                    id = target.closest('.contextMenu').data('id');
+                    name = app.userForID(id).domain;
+                    let puny = `${app.ui.toUnicode(name)}/`;
+                    $(
+                        `.popover[data-name=newConversation] input[name=domain]`
+                    ).val(puny);
+                    app.ui.popover('newConversation');
+                    app.ui.enableTarget(target);
+                    break;
+
+                case 'mentionUser':
+                    id = target.closest('.contextMenu').data('id');
+                    name = `@${app.userForID(id).domain}/`;
+                    let text = $('#message').val();
+                    text = `${text}${name} `;
+                    $('#message').val(text);
+                    app.ui.close();
+                    app.ui.closeMenusIfNeeded();
+                    app.ui.enableTarget(target);
+                    $('#message').focus();
+                    break;
+
+                case 'slapUser':
+                    id = target.closest('.contextMenu').data('id');
+                    name = `@${app.userForID(id).domain}/`;
+                    message = app.replaceCompletions(
+                        `slaps ${name} around a bit with a large trout`
+                    );
+                    data = {
+                        hnschat: 1,
+                        action: message,
+                    };
+                    app.sendMessage(app.conversation, JSON.stringify(data));
+                    app.ui.close();
+                    app.ui.closeMenusIfNeeded();
+                    app.ui.enableTarget(target);
+                    $('#message').focus();
+                    break;
+
+                case 'switchConversation':
+                    id = target.closest('.contextMenu').data('id');
+                    $(`#conversations tr[data-id=${id}]`).click();
+                    app.ui.close();
+                    app.ui.enableTarget(target);
+                    break;
+
+                case 'startConversation':
+                    domain = target
+                        .parent()
+                        .find('input[name=domain]')
+                        .val()
+                        .trim();
+                    domain = app.rtrim(domain, '/').trim();
+                    domain = app.userForName(domain).domain;
+                    message = target.parent().find('input[name=message]').val();
+
+                    if (message.length) {
+                        app.queued.push({
+                            domain: domain,
+                            message: message,
+                        });
+
+                        data = {
+                            domain: domain,
+                        };
+                        app.ws.send(`PM ${JSON.stringify(data)}`);
+                    } else {
+                        data = {
+                            type: action,
+                            message: 'Please enter a message.',
+                        };
+                        app.ui.errorResponse(data);
+                    }
+                    app.ui.enableTarget(target);
+                    break;
+
+                case 'clipboard':
+                    app.ui.copyToClipboard(target);
+                    app.ui.enableTarget(target);
+                    break;
+
+                case 'gifs':
+                case 'emojis':
+                    context = target.closest('.contextMenu');
+                    if (context.length) {
+                        sender = context.data('id');
+                    } else {
+                        sender = target.closest('.messageRow').data('id');
+                    }
+
+                    app.ui.setupReactView(e, sender);
+                    app.ui.popover('react');
+                    app.ui.enableTarget(target);
+                    break;
+
+                case 'createSLD':
+                    e.newTab = true;
+                    app.ui.openURL('/id');
+                    app.ui.enableTarget(target);
+                    break;
+
+                case 'purchaseSLD':
+                    e.newTab = true;
+                    app.ui.openURL(target.data('link'), e);
+                    app.ui.enableTarget(target);
+                    break;
+
+                case 'switchName':
+                    domain = target.data('id');
+                    app.changeDomain(domain);
+                    break;
+
+                case 'newDomain':
+                    if (window.TEST_MODE) {
+                        app.ui.showSection('addDomain');
+                        app.ui.enableTarget(target);
+                        return;
+                    }
+                    app.ui.showSection('addDomain');
+                    app.ui.enableTarget(target);
+                    break;
+
+                case 'addDomain':
+                    if (window.TEST_MODE) {
+                        app.ui.showSection('verifyOptions');
+                        app.ui.enableTarget(target);
+                        return;
+                    }
+                    app.varo.auth().then((auth) => {
+                        if (auth.success) {
+                            let data = {
+                                request: auth.data.request,
+                            };
+                            app.ws.send(`ADDDOMAIN ${JSON.stringify(data)}`);
+                        }
+                        app.ui.enableTarget(target);
+                    });
+                    break;
+
+                case 'verifyDomain':
+                    if (window.TEST_MODE) {
+                        app.ui.showSection('startChatting');
+                        app.ui.enableTarget(target);
+                        return;
+                    }
+                    app.varo.auth().then((auth) => {
+                        if (auth.success) {
+                            let data = {
+                                id: target.closest('.domain').data('id'),
+                                request: auth.data.request,
+                            };
+                            app.ws.send(`VERIFYDOMAIN ${JSON.stringify(data)}`);
+                        }
+                        app.ui.enableTarget(target);
+                    });
+                    break;
+
+                case 'addSLD':
+                    if (window.TEST_MODE) {
+                        app.ui.showSection('verifyOptions');
+                        app.ui.enableTarget(target);
+                        return;
+                    }
+                    sld = target.parent().find('input[name=sld]').val();
+                    tld = target.parent().find('select[name=tld]').val();
+                    data = {
+                        sld: sld,
+                        tld: tld,
+                    };
+                    app.ws.send(`ADDSLD ${JSON.stringify(data)}`);
+                    break;
+
+                case 'deleteDomain':
+                    if (window.TEST_MODE) {
+                        app.ui.showSection('manageDomains');
+                        app.ui.enableTarget(target);
+                        return;
+                    }
+                    domain = target.closest('.domain').data('id');
+                    data = {
+                        id: domain,
+                    };
+                    app.ws.send(`DELETEDOMAIN ${JSON.stringify(data)}`);
+                    break;
+
+                case 'manageDomains':
+                    if (window.TEST_MODE) {
+                        app.ui.showSection('manageDomains');
+                        app.ui.enableTarget(target);
+                        return;
+                    }
+                    app.ui.showSection('manageDomains');
+                    app.ui.enableTarget(target);
+                    break;
+
+                case 'deleteMessage':
+                    message = target.closest('.contextMenu').data('id');
+                    data = {
+                        id: message,
+                    };
+                    app.ws.send(`DELETEMESSAGE ${JSON.stringify(data)}`);
+                    app.ui.close();
+                    app.ui.enableTarget(target);
+                    break;
+
+                case 'pinMessage':
+                    message = target.closest('.contextMenu').data('id');
+                    data = {
+                        conversation: app.conversation,
+                        id: message,
+                    };
+                    app.ws.send(`PINMESSAGE ${JSON.stringify(data)}`);
+                    app.ui.close();
+                    app.ui.enableTarget(target);
+                    break;
+
+                case 'searchUsers':
+                    if (target.hasClass('close')) {
+                        app.ui.searchUsers(false);
+                    } else {
+                        app.ui.searchUsers(true);
+                    }
+                    app.ui.enableTarget(target);
+                    break;
+
+                case 'saveSettings':
+                    let fields = $('.popover[data-name=settings] .local');
+                    $.each(fields, (k, field) => {
+                        let name = $(field).attr('name');
+                        let val = $(field).val();
+                        app.settings[name] = val;
+                    });
+                    localStorage.setItem(
+                        'settings',
+                        JSON.stringify(app.settings)
+                    );
+                    app.loadSettings();
+
+                    data = {
+                        action: 'saveSettings',
+                        domain: app.domain,
+                        settings: {},
+                    };
+
+                    fields = $('.popover[data-name=settings] input.remote');
+                    $.each(fields, (k, field) => {
+                        let name = $(field).attr('name');
+                        let val = $(field).val();
+                        data.settings[name] = val;
+                    });
+
+                    data.settings = JSON.stringify(data.settings);
+
+                    app.api(data).then((r) => {
+                        if (r.success) {
+                            if (r.avatar) {
+                                delete app.avatars[app.domain];
+                                app.userForID(app.domain).avatar = r.avatar;
+                                $(
+                                    `.favicon.loaded[data-id=${app.domain}]`
+                                ).removeClass('loaded');
+                                app.ui.updateAvatars();
+                                app.ws.send(`SAVEDSETTINGS`);
+                            }
+                            app.ui.close();
+                        } else {
+                            data = {
+                                type: action,
+                                message: r.message,
+                            };
+                            app.ui.errorResponse(data);
+                        }
+
+                        app.ui.enableTarget(target);
+                    });
+                    break;
+
+                case 'file':
+                    $('#file')[0].click();
+                    app.ui.enableTarget(target);
+                    break;
+
+                case 'removeAttachment':
+                    let attachment = target.parent().parent();
+                    attachment.remove();
+                    app.ui.showOrHideAttachments();
+                    data = {
+                        id: attachment.data('id'),
+                    };
+                    app.ws.send(`DELETEATTACHMENT ${JSON.stringify(data)}`);
+                    break;
+
+                case 'editProfile':
+                    app.ui.editProfile();
+                    app.ui.enableTarget(target);
+                    break;
+
+                case 'saveProfile':
+                    app.ui.saveProfile();
+                    app.ui.enableTarget(target);
+                    break;
+
+                case 'undoProfile':
+                    app.ui.undoProfile();
+                    app.ui.enableTarget(target);
+                    break;
+
+                case 'close':
+                    app.ui.close();
+                    app.ui.enableTarget(target);
+                    break;
+
+                case 'reload':
+                    window.location.reload();
+                    break;
+
+                case 'startVideo':
+                case 'joinVideo':
+                    app.channelForID(app.conversation).watching = true;
+                    data = {
+                        conversation: app.conversation,
+                    };
+                    if (app.channelForID(app.conversation).video) {
+                        app.ws.send(`JOINVIDEO ${JSON.stringify(data)}`);
+                    } else {
+                        app.ws.send(`STARTVIDEO ${JSON.stringify(data)}`);
+                    }
+                    app.ui.enableTarget(target);
+                    break;
+
+                case 'inviteVideo':
+                    id = target.closest('.contextMenu').data('id');
+
+                    data = {
+                        conversation: app.conversation,
+                        user: id,
+                    };
+                    app.ws.send(`INVITEVIDEO ${JSON.stringify(data)}`);
+                    app.ui.close();
+                    app.ui.closeMenusIfNeeded();
+                    app.ui.enableTarget(target);
+                    break;
+
+                case 'leaveVideo':
+                    if (
+                        Object.keys(
+                            app.channelForID(app.conversation).videoUsers
+                        ).includes(app.domain)
+                    ) {
+                        app.stream.unpublish();
+                    } else {
+                        app.channelForID(app.conversation).watching = false;
+                        app.stream.close();
+                        app.ui.showVideoIfNeeded();
+                    }
+                    data = {
+                        conversation: app.conversation,
+                    };
+                    app.ws.send(`LEAVEVIDEO ${JSON.stringify(data)}`);
+                    app.ui.enableTarget(target);
+                    break;
+
+                case 'endVideo':
+                    if (
+                        Object.keys(
+                            app.channelForID(app.conversation).videoUsers
+                        ).includes(app.domain)
+                    ) {
+                        app.stream.unpublish();
+                    }
+                    data = {
+                        conversation: app.conversation,
+                    };
+                    app.ws.send(`ENDVIDEO ${JSON.stringify(data)}`);
+                    app.ui.enableTarget(target);
+                    break;
+
+                case 'toggleVideo':
+                    app.stream.mute(
+                        'video',
+                        !$(
+                            '.controls .button[data-action=toggleVideo]'
+                        ).hasClass('muted')
+                    );
+                    data = {
+                        conversation: app.conversation,
+                    };
+                    app.ws.send(`MUTEVIDEO ${JSON.stringify(data)}`);
+                    app.ui.enableTarget(target);
+                    break;
+
+                case 'toggleAudio':
+                    app.stream.mute(
+                        'audio',
+                        !$(
+                            '.controls .button[data-action=toggleAudio]'
+                        ).hasClass('muted')
+                    );
+                    data = {
+                        conversation: app.conversation,
+                    };
+                    app.ws.send(`MUTEAUDIO ${JSON.stringify(data)}`);
+                    app.ui.enableTarget(target);
+                    break;
+
+                case 'toggleScreen':
+                    app.stream.toggleScreen();
+                    app.ui.enableTarget(target);
+                    break;
+
+                case 'viewVideo':
+                    data = {
+                        conversation: app.conversation,
+                    };
+                    app.ws.send(`VIEWVIDEO ${JSON.stringify(data)}`);
+                    app.ui.enableTarget(target);
+                    break;
+
+                default:
+                    app.ui.enableTarget(target);
+                    break;
+            }
+        });
+
+        $('html').on('keyup', '.popover[data-name=react] input', (e) => {
+            if (app.isKey(e, 27)) {
+                e.preventDefault();
+                return;
+            }
+
+            let query = $(e.currentTarget)
+                .val()
+                .replace(/[^a-zA-Z0-9]/gi, '')
+                .toLowerCase();
+            if (query) {
+                let emo = $(
+                    '.popover[data-name=react] .section:not([data-name=Search]) .emoji'
+                );
+                let matches = emo.filter((k, em) => {
+                    let aliases = $(em).data('aliases');
+
+                    $.each(aliases, (k, alias) => {
+                        aliases[k] = alias
+                            .replace(/[^a-zA-Z0-9]/gi, '')
+                            .toLowerCase();
+                    });
+
+                    return aliases.join('|').includes(query);
+                });
+
+                $(
+                    '.popover[data-name=react] .grid .section[data-name=Search] .emojis'
+                ).empty();
+                $.each(matches, (k, match) => {
+                    let clone = match.cloneNode(true);
+                    $(
+                        '.popover[data-name=react] .grid .section[data-name=Search] .emojis'
+                    ).append(clone);
+                });
+
+                $('.popover[data-name=react] .grid .section').addClass(
+                    'hidden'
+                );
+                $(
+                    '.popover[data-name=react] .grid .section[data-name=Search]'
+                ).removeClass('hidden');
+            } else {
+                $('.popover[data-name=react] .grid .section').removeClass(
+                    'hidden'
+                );
+                $(
+                    '.popover[data-name=react] .grid .section[data-name=Search]'
+                ).addClass('hidden');
+            }
+        });
+
+        $('html').on('click', '.popover[data-name=react] .emoji', (e) => {
+            let sender = $('.popover[data-name=react]').data('sender');
+            let emoji = $(e.currentTarget);
+            let em = emoji.html();
+
+            if (sender.length) {
+                let reacting = $('.messageRow .hover.visible')
+                    .closest('.messageRow')
+                    .data('id');
+                app.ui.close();
+                let data = {
+                    conversation: app.conversation,
+                    message: reacting,
+                    reaction: em,
+                };
+                app.ws.send(`REACT ${JSON.stringify(data)}`);
+            } else {
+                let field = $('.input #message');
+                let current = field.val();
+                let split = Array.from(current);
+                let position = field[0].selectionStart;
+                let added = app.replaceRange(current, position, position, em);
+                field.val(added);
+                app.ui.close();
+                $('.input #message').focus();
+                app.ui.setCaretPosition(field[0], position + em.length);
+            }
+        });
+
+        $('html').on('click', '.reaction', (e) => {
+            let target = $(e.currentTarget);
+            let reacting = target.closest('.messageRow').data('id');
+            let em = target.data('reaction');
+
+            let data = {
+                conversation: app.conversation,
+                message: reacting,
+                reaction: em,
+            };
+            app.ws.send(`REACT ${JSON.stringify(data)}`);
+        });
+
+        $('html').on('click', '#react .tab', (e) => {
+            let target = $(e.target);
+            let name = target.data('name');
+            app.ui.switchReactTab(name);
+        });
+
+        $('html').on('click', '#react .category', (e) => {
+            let target = $(e.target);
+            let term = target.data('term');
+            $('#react input[name=searchGifs]').val(term);
+            app.ui.searchGifs(term);
+        });
+
+        $('html').on('input', '#react input[name=searchGifs]', (e) => {
+            let target = $(e.target);
+            let value = target.val().trim();
+
+            clearInterval(this.gifTimer);
+            this.lastGifSearch = app.time();
+            this.gifTimer = setInterval(() => {
+                let timeSince = app.time() - this.lastGifSearch;
+                if (timeSince >= 1) {
+                    app.ui.searchGifs(value);
+                    clearInterval(this.gifTimer);
+                }
+            }, 100);
+        });
+
+        $('html').on('click', '#react .gif', (e) => {
+            let target = $(e.target);
+            let gif = target.data('full');
+
+            let data = {
+                hnschat: 1,
+                attachment: gif,
+            };
+            app.sendMessage(app.conversation, JSON.stringify(data));
+            app.ui.close();
+        });
+
+        $('html').on('click', (e) => {
+            let target = $(e.currentTarget);
+        });
+
+        $('html').on(
+            'click',
+            '#users .user, .messageRow .user, .messageRow .favicon, .inline.nick, .header .favicon, .inline.channel, .cam table .user, .screen table .user, #videoInfo .avatar > div',
+            (e) => {
+                let target = $(e.currentTarget);
+
+                if (!app.userForID(app.domain).locked) {
+                    app.ui.handleRightClick(e, target);
+                }
+            }
+        );
+
+        $('html').on(
+            'input paste keydown focus click',
+            '.contextMenu[data-name=userContext] .bioHolder .bio',
+            (e) => {
+                app.ui.updateBioLimit(e);
+            }
+        );
+
+        $(window).on('contextmenu', (e) => {
+            let target = $(e.target);
+
+            if (
+                ['INPUT', 'TEXTAREA', 'A'].includes(target.prop('tagName')) ||
+                target.hasClass('body') ||
+                (target.hasClass('inline') &&
+                    !(target.hasClass('nick') || target.hasClass('channel')))
+            ) {
+                return;
+            } else {
+                e.preventDefault();
+
+                app.ui.handleRightClick(e, target);
+            }
+        });
+
+        $('html').on('touchstart', '.messageRow', (e) => {
+            let target = $(e.target);
+            if (
+                !(
+                    target.hasClass('messageRow') ||
+                    target.hasClass('message') ||
+                    target.hasClass('body') ||
+                    target.hasClass('main') ||
+                    target.hasClass('msg') ||
+                    target.hasClass('hover')
+                )
+            ) {
+                return;
+            }
+
+            $('body').addClass('touching');
+            this.longPress = e.timeStamp;
+            this.longPressTimer = setTimeout(() => {
+                app.ui.handleRightClick(e, target);
+            }, 500);
+        });
+
+        $('html').on('touchcancel', '.messageRow', (e) => {
+            $('body').removeClass('touching');
+            this.longPress = 0;
+            clearTimeout(this.longPressTimer);
+        });
+
+        $('html').on('touchend', '.messageRow', (e) => {
+            if ($('#blackout').hasClass('shown')) {
+                setTimeout(() => {
+                    this.longPress = 0;
+                    clearTimeout(this.longPressTimer);
+                    $('body').removeClass('touching');
+                }, 500);
+            }
+
+            let duration = e.timeStamp - this.longPress;
+            if (duration < 500) {
+                this.longPress = 0;
+                clearTimeout(this.longPressTimer);
+                $('body').removeClass('touching');
+            }
+        });
+
+        $('html').on('click', '.header .icon.menu', (e) => {
+            if ($('#conversations').hasClass('showing')) {
+                $('body').removeClass('menu');
+                $('#conversations').removeClass('showing');
+            } else {
+                if ($('#users').hasClass('showing')) {
+                    $('body').removeClass('menu');
+                    $('#users').removeClass('showing');
+                }
+                $('body').addClass('menu');
+                $('#conversations').addClass('showing');
+            }
+        });
+
+        $('html').on('click', '.header .icon.users', (e) => {
+            if ($('#holder[data-type=pms]').length) {
+                return;
+            }
+
+            if ($('#users').hasClass('showing')) {
+                $('body').removeClass('menu');
+                $('#users').removeClass('showing');
+            } else {
+                if ($('#conversations').hasClass('showing')) {
+                    $('body').removeClass('menu');
+                    $('#conversations').removeClass('showing');
+                }
+                $('body').addClass('menu');
+                $('#users').addClass('showing');
+            }
+        });
+
+        $('html').on('keyup', 'input', (e) => {
+            if (app.isKey(e, 13)) {
+                let target = $(e.target);
+                let submit = target.parent().find('.button').last();
+                if (!submit.length) {
+                    submit = target.closest('.section').find('.button').last();
+                }
+                submit.click();
+            }
+        });
+
+        $('html').on('keydown', 'input[name=hns]', (e) => {
+            let key = e.key;
+            let keyCode = app.key(e);
+            let match = key.match(/[a-z ]/g);
+            if (
+                match &&
+                !(e.shiftKey || e.metaKey || e.ctrlKey) &&
+                !(keyCode >= 37 && keyCode <= 40)
+            ) {
+                e.preventDefault();
+            }
+        });
+
+        $('html').on('keyup', '#users input[name=search]', (e) => {
+            if (app.isKey(e, 27)) {
+                app.ui.searchUsers(false);
+            } else {
+                let target = $(e.target);
+                let value = target.val().trim();
+                app.ui.queryUsers(value);
+            }
+        });
+
+        $('html').on('change', '#file', (e) => {
+            let file = $(e.currentTarget)[0].files[0];
+
+            if (file) {
+                let url = URL.createObjectURL(file);
+                let attachment = $(`
 					<div class="attachment" style="background-image: url(${url})">
 						<div class="removeHolder">
 							<div class="icon action remove" data-action="removeAttachment"></div>
@@ -1108,112 +1257,123 @@ export class listeners {
 						<div class="uploading lds-spinner"><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div></div>
 					</div>
 				`);
-				$("#attachments").append(attachment);
-				app.ui.showOrHideAttachments();
+                $('#attachments').append(attachment);
+                app.ui.showOrHideAttachments();
 
-				let data = new FormData;
-			    data.append("file", file);
-			    data.append("key", app.session);
-				app.upload(data, attachment).then(r => {
-					attachment.find(".uploading").remove();
+                let data = new FormData();
+                data.append('file', file);
+                data.append('key', app.session);
+                app.upload(data, attachment).then((r) => {
+                    attachment.find('.uploading').remove();
 
-					if (r.success) {
-						attachment.attr("data-id", r.id);
-					}
-					else {
-						alert(r.message);
-						attachment.remove();
-					}
+                    if (r.success) {
+                        attachment.attr('data-id', r.id);
+                    } else {
+                        alert(r.message);
+                        attachment.remove();
+                    }
 
-					app.ui.showOrHideAttachments();
-					$("#message").focus();
-				});
-			}
-		});
+                    app.ui.showOrHideAttachments();
+                    $('#message').focus();
+                });
+            }
+        });
 
-		$("html").on("input paste keydown focus click", ".popover[data-name=settings] input.color", e => {
-			let target = $(e.currentTarget);
-			let name = `--${target.attr("name")}`;
-			let value = target.val();
-			app.ui.root.style.setProperty(name, value);
-		});
+        $('html').on(
+            'input paste keydown focus click',
+            '.popover[data-name=settings] input.color',
+            (e) => {
+                let target = $(e.currentTarget);
+                let name = `--${target.attr('name')}`;
+                let value = target.val();
+                app.ui.root.style.setProperty(name, value);
+            }
+        );
 
-		$("html").on("change", ".popover[data-name=settings] select[name=chatDisplayMode]", e => {
-			let target = $(e.target);
-			let value = target.val();
-			app.ui.chatDisplayMode(value);
-		});
+        $('html').on(
+            'change',
+            '.popover[data-name=settings] select[name=chatDisplayMode]',
+            (e) => {
+                let target = $(e.target);
+                let value = target.val();
+                app.ui.chatDisplayMode(value);
+            }
+        );
 
-		$("html").on("click", ".messageRow .reply .body", e => {
-			let target = $(e.target);
-			let message = target.closest(".reply").data("id");
-			app.ui.gotoMessage(message);
-		});
+        $('html').on('click', '.messageRow .reply .body', (e) => {
+            let target = $(e.target);
+            let message = target.closest('.reply').data('id');
+            app.ui.gotoMessage(message);
+        });
 
-		$("html").on("click", ".pinnedMessage", e => {
-			let target = $(e.target);
-			if (target.hasClass("delete")) {
-				return;
-			}
-			let message = app.channelForID(app.conversation).pinned;
-			app.ui.gotoMessage(message);
-		});
+        $('html').on('click', '.pinnedMessage', (e) => {
+            let target = $(e.target);
+            if (target.hasClass('delete')) {
+                return;
+            }
+            let message = app.channelForID(app.conversation).pinned;
+            app.ui.gotoMessage(message);
+        });
 
-		$("html").on("click", "#jumpToPresent", e => {
-			app.ui.setInThePast(false);
-			app.ui.clear("messages");
-			app.ui.messagesLoading(true);
-			app.getMessages();
-		});
+        $('html').on('click', '#jumpToPresent', (e) => {
+            app.ui.setInThePast(false);
+            app.ui.clear('messages');
+            app.ui.messagesLoading(true);
+            app.getMessages();
+        });
 
-		$(window).on("message", e => {
-			if (e.originalEvent.data) {
-				switch (e.originalEvent.data) {
-					case "handlePush":
-						app.handlePush();
-						break;
+        $(window).on('message', (e) => {
+            if (e.originalEvent.data) {
+                switch (e.originalEvent.data) {
+                    case 'handlePush':
+                        app.handlePush();
+                        break;
 
-					case "mobileApp":
-						localStorage.setItem("mobile", true);
-						break;
-				}
-			}
-		});
-	}
+                    case 'mobileApp':
+                        localStorage.setItem('mobile', true);
+                        break;
+                }
+            }
+        });
+    }
 
-	// Add test mode initialization method
-	initializeTestMode(app) {
-		// Populate TLDs dropdown
-		if (window.TEST_DATA && window.TEST_DATA.tlds) {
-			const tldSelect = $("select[name=tld]");
-			window.TEST_DATA.tlds.forEach(tld => {
-				tldSelect.append(`<option value="${tld}">${tld}</option>`);
-			});
-		}
+    // Add test mode initialization method
+    initializeTestMode(app) {
+        // Populate TLDs dropdown
+        if (window.TEST_DATA && window.TEST_DATA.tlds) {
+            const tldSelect = $('select[name=tld]');
+            window.TEST_DATA.tlds.forEach((tld) => {
+                tldSelect.append(`<option value="${tld}">${tld}</option>`);
+            });
+        }
 
-		// Populate domains list if in manage domains section
-		if (window.TEST_DATA && window.TEST_DATA.domains) {
-			const domainsContainer = $(".domains");
-			window.TEST_DATA.domains.forEach(domain => {
-				const domainHtml = `
+        // Populate domains list if in manage domains section
+        if (window.TEST_DATA && window.TEST_DATA.domains) {
+            const domainsContainer = $('.domains');
+            window.TEST_DATA.domains.forEach((domain) => {
+                const domainHtml = `
 					<div class="domain" data-id="${domain.id}">
 						<div class="name">${domain.id}</div>
 						<div class="status ${domain.verified ? 'verified' : 'unverified'}">
 							${domain.verified ? 'Verified' : 'Unverified'}
 						</div>
 						<div class="actions">
-							${!domain.verified ? '<div class="button" data-action="verifyDomain">Verify</div>' : ''}
+							${
+                                !domain.verified
+                                    ? '<div class="button" data-action="verifyDomain">Verify</div>'
+                                    : ''
+                            }
 							<div class="button" data-action="deleteDomain">Delete</div>
 						</div>
 					</div>
 				`;
-				domainsContainer.append(domainHtml);
-			});
-		}
+                domainsContainer.append(domainHtml);
+            });
+        }
 
-		// Set verification code if in verification section
-		if (window.TEST_DATA && window.TEST_DATA.verification_code) {
-			$("#verifyDomain #code").text(window.TEST_DATA.verification_code);
-		}
-	}
+        // Set verification code if in verification section
+        if (window.TEST_DATA && window.TEST_DATA.verification_code) {
+            $('#verifyDomain #code').text(window.TEST_DATA.verification_code);
+        }
+    }
 }

--- a/chat-client/assets/js/script.js
+++ b/chat-client/assets/js/script.js
@@ -5,1418 +5,1454 @@ let { stream } = await import(`./stream.js?r=${revision}`);
 let { listeners } = await import(`./listeners.js?r=${revision}`);
 
 function log(string) {
-	console.log(string);
+    console.log(string);
 }
 
 export class HNSChat {
-	constructor() {
-		window.hnschat = this;
-		
-		try {
-			this.varo = new Varo();
-		}
-		catch {}
-
-		this.mobile = false;
-
-		this.host = window.location.host;
-		this.hash = window.location.hash.substring(1);
-		this.page;
-		this.data;
-
-		this.ui = new ui(this);
-		this.ws = new ws(this);
-		this.listeners = new listeners(this);
-		this.e2ee = new e2ee();
-
-		this.streamURL = "https://media.hns.chat/stream";
-		this.stream;
-
-		this.isActive = true;
-
-		this.keys;
-		this.session;
-		this.domain;
-		this.domains;
-		this.staked;
-		this.conversation;
-		this.settings;
-		this.messages = [];
-		this.seen = {};
-
-		this.users;
-
-		this.channels;
-		this.pms;
-
-		this.tab = "channels";
-
-		this.timeFormat = "g:i A";
-		this.dateFormat = "F jS, Y";
-
-		this.gotChannels;
-		this.gotPms;
-		this.gotMentions;
-
-		this.loadingMessages;
-		this.replying;
-		this.queued = [];
-
-		this.typing;
-		this.typingSent;
-		this.typingDelay = 2;
-		this.typingSendDelay = 1;
-		this.lastTyped;
-		this.typers = {};
-
-		this.active = [];
-
-		this.avatars = {};
-
-		this.action = "\x01ACTION";
-
-		this.commands = ["me", "shrug", "slap"];
-
-		this.hasBob;
-
-		this.init();
-	}
-
-	varoLoaded() {
-		if (typeof this.varo !== "undefined") {
-			return true;
-		}
-		return false
-	}
-
-	getPage() {
-		let pathname = document.location.pathname;
-		let match = pathname.match(/\/(?<page>.+?)(?:\/(?<data>.+)|$)/);
-		if (match) {
-			let groups = match.groups;
-
-			if (groups.page) {
-				this.page = groups.page;
-			}
-			if (groups.data) {
-				this.data = groups.data;
-			}
-		}
-		else {
-			this.page = "chat";
-		}
-	}
-
-	async api(data) {
-		if (this.session) {
-			data.session = this.session;
-		}
-
-		let output = new Promise(function(resolve) {
-			$.post("/api", JSON.stringify(data), function(response){
-				if (response) {
-					let json = JSON.parse(response);
-					resolve(json);
-				}
-			});
-		});
-
-		return await output;
-	}
-
-	time() {
-		return Math.floor(Date.now() / 1000);
-	}
-
-	handlePush(init=false) {
-		if (localStorage.handlePush) {
-			try {
-				let info = JSON.parse(localStorage.handlePush);
-				
-				localStorage.setItem("domain", info.domain);
-				localStorage.setItem("conversation", info.conversation);
-
-				if (!init) {
-					if (this.domain !== info.domain) {
-						this.changeDomain(info.domain);
-					}
-					this.changeConversation(info.conversation);
-				}
-			}
-			catch {}
-		}
-		localStorage.removeItem("handlePush");
-	}
-
-	autoCreateUser() {
-		// example url: http://localhost/id?name=yogibear&autocreate=true
-		this.ui.showSection('addDomain');
-		let urlParams = new URLSearchParams(window.location.search);
-		let name = urlParams.get('name');
-		let autocreate = urlParams.get('autocreate');
-		if (autocreate === 'true') {
-			let sld = name;
-			let tld = 'chrischannel';
-			let data = {
-				sld: sld,
-				tld: tld
-			}
-			this.ws.send(`ADDSLD ${JSON.stringify(data)}`);
-			// this.ui.showSection('manageDomains');
-			window.location.href = '/';
-		}
-	}
-
-	async init() {
-		this.handlePush(true);
-		
-		this.getPage();
-		switch (this.page) {
-			case "sync":
-				this.loadSync();
-				break;
-
-			case "buy":
-				break;
-
-			default:
-				try {
-					this.keys = JSON.parse(localStorage.keys);
-				}
-				catch {
-					this.e2ee.generateKeys().then(r => {
-						this.keys = r;
-						localStorage.setItem("keys", JSON.stringify(this.keys));
-					});
-				}
-
-				if (this.hash) {
-					localStorage.setItem("hash", this.hash);
-					history.pushState("", document.title, window.location.pathname + window.location.search);
-				}
-				else {
-					this.hash = localStorage.hash;
-				}
-
-				this.mobile = localStorage.mobile || false;
-
-				this.session = localStorage.session;
-				this.domain = localStorage.domain;
-				this.conversation = localStorage.conversation;
-
-				try {
-					this.settings = JSON.parse(localStorage.settings);
-					this.loadSettings();
-				}
-				catch {
-					this.settings = {};
-				}
-
-				this.firstLaunch = localStorage.firstLaunch;
-				if (!this.firstLaunch) {
-					localStorage.setItem("firstLaunch", this.time());
-				}
-
-				await this.startSession();
-				await this.setPublicKey();
-				await this.ws.connect();
-				this.autoCreateUser();
-				break;
-		}
-
-		switch (this.page) {
-			case "chat":
-				this.stream = new stream(this);
-				this.ui.setConversationTab();
-				this.ui.setupSync();
-				this.ui.setupNotifications();
-				break;
-		}
-
-		if (typeof bob3 != "undefined") {
-			this.hasBob = true;
-			this.ui.hasBob();
-		}
-	}
-
-	loadSettings() {
-		Object.keys(this.settings).forEach((setting, k) => {
-			let value = this.settings[setting];
-			switch (setting) {
-				case "chatDisplayMode":
-					this.ui.chatDisplayMode(value);
-					break;
-
-				default:
-					this.ui.root.style.setProperty(`--${setting}`, value);
-					break;
-			}
-		});
-	}
-
-	loadSync() {
-		let hash = this.hash;
-		let db64 = this.db64(hash);
-		let json = JSON.parse(db64);
-		this.session = json.session;
-		localStorage.setItem("session", this.session);
-
-		if (json.settings) {
-			this.settings = json.settings;
-			localStorage.setItem("settings", JSON.stringify(this.settings));
-		}
-
-		let data = {
-			action: "getPublicKey"
-		}
-		this.api(data).then(r => {
-			if (r.success) {
-				let pubkey = JSON.parse(r.pubkey);
-				this.e2ee.importKey(pubkey.x, pubkey.y, json.privkey).then(privkey => {
-					this.keys = {
-						privateKeyJwk: privkey,
-						publicKeyJwk: pubkey
-					};
-
-					localStorage.setItem("keys", JSON.stringify(this.keys));
-					this.ui.openURL("/");
-				});
-			}
-		});
-	}
-
-	db64(str) {
-		str = (str + '==='.slice((str.length + 3) % 4)).replace(/-/g, '+').replace(/_/g, '/');
-		return atob(str);
-	}
-
-	b64(str) {
-		str.replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
-		return btoa(str);
-	}
-
-	syncLink() {
-		let data = {
-			session: this.session,
-			privkey: this.keys.privateKeyJwk.d,
-			settings: this.settings
-		}
-
-		let json = JSON.stringify(data);
-		let encoded = this.b64(json);
-		let link = "https://"+this.host+"/sync#"+encoded;
-
-		return link;
-	}
-
-	regex(pattern, string) {
-		return [...string.matchAll(pattern)];
-	}
-
-	rtrim(str, chr) {
-	  let rgxtrim = (!chr) ? new RegExp('\\s+$') : new RegExp(chr+'+$');
-	  return str.replace(rgxtrim, '');
-	}
-
-	replaceRange(s, start, end, substitute) {
-		let before = s.substr(0, start);
-		let after = s.substr(end, (s.length -end));
-
-		return before+substitute+after;
-	}
-
-	sorted(array, by) {
-		return array.sort((a, b) => a[by].localeCompare(b[by]));
-	}
-
-	isKey(e, key) {
-		if (this.key(e) == key) {
-			return true
-		}
-		return false;
-	}
-
-	key(e) {
-		return e.which || e.keyCode;
-	}
-
-	keyName(e) {
-		return e.key;
-	}
-
-	setPublicKey() {
-		let data = {
-			action: "setPublicKey",
-			pubkey: JSON.stringify(this.keys.publicKeyJwk)
-		};
-
-		return this.api(data);
-	}
-
-	async startSession() {
-		if (this.session) {
-			return;
-		}
-
-		let data = {
-			"action": "startSession"
-		};
-
-		return this.api(data).then(r => {
-			this.session = r.session;
-			localStorage.setItem("session", r.session);
-		});
-	}
-
-	sendDomain() {
-		if (!this.domain) {
-			if (this.domains.length) {
-				this.domain = this.domains[0].id;
-				localStorage.setItem("domain", this.domain);
-			}
-			else {
-				this.ui.openURL("/id");
-				return;
-			}
-		}
-		this.ws.send(`DOMAIN ${this.domain}`);
-	}
-
-	message(data) {
-		let message = data.toString();
-		let parsed = message.match(/(?<command>[A-Z]+)(\s(?<body>.+))?/);
-		this.handle(parsed.groups);
-	}
-
-	async handle(parsed) {
-		let command = parsed.command;
-		let body = parsed.body;
-		let push = false;
-
-		if (body) {
-			try {
-				body = JSON.parse(body);
-
-				for (var k in body) {
-					try {
-						body[k] = JSON.parse(body[k]);
-					}
-					catch {}
-
-					for (var i in body[k]) {
-						try {
-							body[k][i] = JSON.parse(body[k][i]);
-						}
-						catch {}
-					}
-				}
-			}
-			catch {}
-		}
-
-		switch (command) {
-			case "SUCCESS":
-				switch (body.type) {
-					case "ADDDOMAIN":
-					case "ADDSLD":
-						this.ui.enableButton(body.type);
-						this.ui.handleSuccess(body);
-						break;
-
-					case "DELETEDOMAIN":
-						this.ui.removeDomain(body.id);
-						break;
-
-					case "VERIFYDOMAIN":
-						this.ui.handleSuccess(body);
-						break;
-
-					case "GETADDRESS":
-						this.ui.paymentResponse(body);
-						break;
-				}
-				break;
-
-			case "ERROR":
-				switch (body.type) {
-					case "ADDDOMAIN":
-						this.ui.errorResponse(body);
-						break;
-
-					case "ADDSLD":
-						this.ui.enableButton(body.type);
-						this.ui.errorResponse(body);
-						break;
-
-					case "MESSAGES":
-						this.ui.setUserList();
-						this.ui.messagesLoading(false);
-						this.ui.setGatedView(body);
-						this.ui.markEmptyIfNeeded();
-						this.loadingMessages = false;
-						break;
-
-					case "DOMAIN":
-						this.domain = null;
-						this.sendDomain();
-						break;
-
-					case "PM":
-						if (body.id) {
-							let otherUser = this.otherUserFromPM(body.id);
-							let queuedMessage = this.queuedMessage(otherUser.domain);
-							if (queuedMessage) {
-								this.ui.changeConversation(body.id);
-								this.ui.close();
-							}
-						}
-						else {
-							this.ui.errorResponse(body);
-						}
-						break;
-
-					case "GETADDRESS":
-						this.ui.paymentResponse(body);
-						break;
-				}
-				break;
-
-			case "IDENTIFIED":
-				if (this.page !== "sync") {
-					if (body.seen) {
-						this.seen = body.seen;
-					}
-					this.ws.send("DOMAINS");
-				}
-				break;
-
-			case "DOMAINS":
-				this.domains = body;
-				this.ui.domains(this.domains);
-
-				switch (this.page) {
-					case "chat":
-						this.sendDomain();
-						break;
-
-					case "id":
-					case "invite":
-						this.ws.send(`STAKED`);
-						break;
-				}
-				break;
-
-			case "STAKED":
-				this.staked = body;
-				this.ui.stakedDomains(body);
-				break;
-
-			case "DOMAIN":
-				this.ui.updateDomainSelect();
-				this.ws.send("USERS");
-				break;
-
-			case "USERS":
-				$.each(body, (k, user) => {
-					body[k].domain = body[k].domain.toString();
-				});
-				this.users = body;
-				this.ws.send(`PING`);
-				this.ws.send(`CHANNELS`);
-				this.ws.send(`PMS`);
-				break;
-
-			case "USER":
-				this.users = this.users.filter(u => {
-					return u.id != body.id;
-				});
-
-				body.domain = body.domain.toString();
-				this.users.push(body);
-
-				if (body.id !== this.domain) {
-					let pm = this.pmWithUser(body.id);
-					if (pm) {
-						this.makeSecret(pm);
-					}
-				}
-
-				this.ui.setUserList();
-				this.ui.updateConversations();
-				break;
-
-			case "CHANNELS":
-				this.ui.clear("channels");
-				this.channels = body;
-				if (this.channels.length) {
-					let sorted = this.channels.sort((a, b) => {
-						if (("activity" in a) && !("activity" in b)) {
-							return 1;
-						}
-						if (("activity" in b) && !("activity" in a)) {
-							return -1;
-						}
-						if (!("activity" in a) && !("activity" in b)) {
-							return 0;
-						}
-						return a.activity - b.activity;
-					});
-					$.each(sorted.reverse(), (k, channel) => {
-						this.ui.conversation("channels", channel);
-					});
-				}
-				this.ui.updateConversations();
-				this.gotChannels = true;
-				this.ws.send(`MENTIONS`);
-				this.ready(true);
-				break;
-
-			case "CHANNEL":
-				this.channels.push(body);
-				this.ui.conversation("channels", body);
-				this.ui.updateConversations();
-				break;
-
-			case "PMS":
-				this.ui.clear("pms");
-				this.pms = body;
-				if (this.pms.length) {
-					let sorted = this.pms.sort((a, b) => {
-						return b.activity - a.activity;
-					});
-					$.each(sorted, (k, conversation) => {
-						this.makeSecret(conversation).then((key) => {
-							this.ui.conversation("pms", conversation);
-
-							if (k == this.pms.length - 1) {
-								this.ui.updateConversations();
-								this.gotPms = true;
-								this.ready(true);
-							}
-						});
-					});
-				}
-				else {
-					this.ui.updateConversations();
-					this.gotPms = true;
-					this.ready(true);
-				}
-				break;
-
-			case "PM":
-				this.pms.push(body);
-				this.makeSecret(body).then((key) => {
-					this.ui.conversation("pms", body);
-
-					let otherUser = this.otherUserFromPM(body.id);
-					let queuedMessage = this.queuedMessage(otherUser.domain);
-					if (queuedMessage) {
-						this.ui.changeConversation(body.id);
-						this.ui.close();
-					}
-				});
-				break;
-
-			case "MESSAGES":
-				this.ui.setUserList();
-				this.ui.insertMessages(body, true).then(() => {
-					this.ui.messagesLoading(false);
-
-					if (body.at) {
-						this.ui.scrollToMessage(body.at);
-					}
-					else if (body.after) {
-						this.ui.backInPresent(body);
-					}
-
-					if (!this.isChannel(this.conversation)) {
-						let otherUser = this.otherUserFromPM(this.conversation);
-						let queuedMessage = this.queuedMessage(otherUser.domain);
-						if (queuedMessage) {
-							this.queued = this.queued.filter(q => {
-								return q.domain !== queuedMessage.domain;
-							});
-							this.sendMessage(this.conversation, queuedMessage.message);
-						}
-					}
-				});
-				break;
-
-			case "MESSAGE":
-			case "NOTICE":
-				delete this.typers[body.user];
-
-				let c;
-				if (this.isChannel(body.conversation)) {
-					c = this.channelForID(body.conversation);
-				}
-				else {
-					c = this.pmForID(body.conversation);
-				}
-				c.activity = body.time;
-
-				this.ui.updateConversations();
-				this.ui.moveConversationToTop(body.conversation);
-
-				await this.decryptMessageIfNeeded(body.conversation, body).then(decrypted => {
-					body.message = decrypted[0];
-					if (body.p_message) {
-						body.p_message = decrypted[1];
-					}
-
-					if (typeof body.message == "object") {
-						if (body.message.message) {
-							body.message.message = body.message.message.toString();
-						}
-						body.message = JSON.stringify(body.message);
-					}
-					if (typeof body.p_message == "object") {
-						if (body.p_message.message) {
-							body.p_message.message = body.p_message.message.toString();
-						}
-						body.p_message = JSON.stringify(body.p_message);
-					}
-
-					body.message = body.message.toString();
-					if (body.p_message) {
-						body.p_message = body.p_message.toString();
-					}
-
-					if (!this.ui.inThePast && body.conversation == this.conversation) {
-						let data = {
-							messages: [body]
-						}
-						this.ui.insertMessages(data);
-						this.seen[this.conversation] = this.time();
-						
-						if (!this.isActive) {
-							if (this.isChannel(body.conversation)) {
-								if (this.mentionsMe(body.message)) {
-									push = "mention";
-								}
-								else if (this.replyingToMe(body)) {
-									push = "reply";
-								}
-							}
-							else {
-								push = "pm";
-							}
-						}
-					}
-					else {
-						if (this.isChannel(body.conversation)) {
-							if (this.mentionsMe(body.message)) {
-								this.ui.markMention(body.conversation, true);
-								push = "mention";
-							}
-							else if (this.replyingToMe(body)) {
-								push = "reply";
-							}
-						}
-						else {
-							push = "pm";
-						}
-					}
-
-					if (push) {
-						if (body.user !== this.domain) {
-							let name;
-
-							switch (push) {
-								case "pm":
-									name = this.ui.toUnicode(this.userForID(body.user).domain);
-									break;
-
-								case "mention":
-								case "reply":
-									name = `${this.ui.toUnicode(this.userForID(body.user).domain)} - #${this.ui.toUnicode(c.name)}`;
-									break;
-							}
-
-							let subtitle = this.ui.messageSummary(decrypted[0]);
-							subtitle = this.ui.stripHTML(this.ui.replaceIds(subtitle)); 
-							this.ui.sendNotification(name, subtitle, body.conversation);
-						}
-					}
-				});
-				break;
-
-			case "DELETEMESSAGE":
-				this.ui.deleteMessage(body.id);
-				break;
-
-			case "REACT":
-				if (body.conversation == this.conversation) {
-					let message = this.messages.filter(m => {
-						return m.id == body.message;
-					})[0];
-
-					try {
-						let json = JSON.parse(message.reactions);
-
-						if (!Object.keys(json).includes(body.reaction)) {
-							json[body.reaction] = [];
-						}
-
-						if (json[body.reaction].includes(body.user)) {
-							let x = json[body.reaction].indexOf(body.user);
-							delete json[body.reaction].splice(x, 1);
-
-							if (!Object.keys(json[body.reaction]).length) {
-								delete json[body.reaction];
-							}
-						}
-						else {
-							json[body.reaction].push(body.user);
-						}
-
-						message.reactions = JSON.stringify(json);
-						this.ui.updateReactions(body.message);
-						this.seen[this.conversation] = this.time();
-					}
-					catch {}
-				}
-				break;
-
-			case "TYPING":
-				this.typers[body.from] = {
-					to: body.to,
-					time: this.time()
-				}
-				break;
-
-			case "MENTIONS":
-				this.ui.updateMentions(body);
-				this.gotMentions = true;
-				this.ready(true);
-				break;
-
-			case "PONG":
-				this.updateActiveUsers(body.active);
-				//this.ui.checkVersion(body.version);
-				break;
-
-			case "PINMESSAGE":
-				this.channelForID(body.conversation).pinned = body.id;
-				if (this.conversation == body.conversation) {
-					this.ui.setPinnedMessage();
-				}
-				break;
-
-			case "STARTVIDEO":
-				this.ui.muteAll();
-				this.channelForID(body.conversation).video = true;
-				this.channelForID(body.conversation).videoUsers = body.users;
-				this.ui.showVideoIfNeeded();
-				break;
-
-			case "INVITEVIDEO":
-				this.channelForID(body.conversation).videoSpeakers = body.speakers;
-				this.ui.showVideoIfNeeded();
-				break;
-
-			case "JOINVIDEO":
-				if (body.users) {
-					this.channelForID(body.conversation).videoUsers = body.users;
-				}
-				if (body.watchers) {
-					this.channelForID(body.conversation).videoWatchers = body.watchers;
-				}
-				if (body.speakers) {
-					this.channelForID(body.conversation).videoSpeakers = body.speakers;
-				}
-				this.ui.showVideoIfNeeded();
-				break;
-
-			case "VIEWVIDEO":
-				if (body.users) {
-					this.channelForID(body.conversation).videoUsers = body.users;
-				}
-				if (body.watchers) {
-					this.channelForID(body.conversation).videoWatchers = body.watchers;
-					if (body.watchers.includes(this.domain)) {
-						this.channelForID(body.conversation).watching = true;
-					}
-				}
-				this.ui.showVideoIfNeeded();
-				break;
-
-			case "LEAVEVIDEO":
-				if (body.users) {
-					this.channelForID(body.conversation).videoUsers = body.users;
-				}
-				if (body.watchers) {
-					this.channelForID(body.conversation).videoWatchers = body.watchers;
-				}
-				if (body.speakers) {
-					this.channelForID(body.conversation).videoSpeakers = body.speakers;
-				}
-				this.ui.showVideoIfNeeded();
-				break;
-
-			case "ENDVIDEO":
-				this.endVideo(body.conversation);
-				break;
-
-			case "MUTEVIDEO":
-			case "MUTEAUDIO":
-				let toggle;
-				let user = this.channelForID(body.conversation).videoUsers[body.user];
-				switch (command) {
-					case "MUTEVIDEO":
-						toggle = "toggleVideo";
-						user.video = !user.video;
-						break;
-
-					case "MUTEAUDIO":
-						toggle = "toggleAudio";
-						user.audio = !user.audio;
-						break;
-				}
-				this.ui.updateVideoUsers();
-				if (body.user == this.domain) {
-					this.ui.setMute(toggle, -1);
-				}
-				break;
-
-			case "CONNECTED":
-				if (this.userForID(body)) {
-					this.userForID(body).active = true;
-					this.ui.updateUserList();
-					this.ui.updateConversations();
-				}
-				break;
-
-			case "DISCONNECTED":
-				if (this.userForID(body)) {
-					this.userForID(body).active = false;
-					this.ui.updateUserList();
-					this.ui.updateConversations();
-				}
-				break;
-		}
-	}
-
-	endAllVideo() {
-		try {
-			this.stream.close();
-			$.each(this.channels, (k, c) => {
-				this.endVideo(c.id);
-			});
-		}
-		catch {};
-	}
-
-	endVideo(conversation) {
-		this.channelForID(conversation).videoUsers = {};
-		this.channelForID(conversation).videoWatchers = [];
-		this.channelForID(conversation).videoSpeakers = [];
-		this.channelForID(conversation).video = false;
-		this.channelForID(conversation).watching = false;
-		this.ui.showVideoIfNeeded();
-	}
-
-	currentVideoUsers() {
-		return this.channelForID(this.conversation).videoUsers;
-	}
-
-	updateActiveUsers(active) {
-		if (this.users) {
-			let current = this.active;
-			this.active = active;
-
-			current.forEach(u => {
-				if (!active.includes(u)) {
-					let user = this.userForID(u);
-					user.active = false;
-				}
-			});
-
-			active.forEach(u => {
-				let user = this.userForID(u);
-				user.active = true;
-			});
-
-			this.ui.updateUserList();
-			this.ui.updateConversations();
-		}
-	}
-
-	otherUserFromPM(id) {
-		let pm = this.pmForID(id);
-		let otherUserID = this.otherUser(pm.users);
-		let otherUser = this.userForID(otherUserID);
-		return otherUser;
-	}
-
-	queuedMessage(domain) {
-		return this.queued.filter(q => {
-			return q.domain == domain;
-		})[0];
-	}
-
-	ready(bool) {
-		if (bool) {
-			if (this.gotChannels && this.gotPms && this.gotMentions) {
-				this.ui.changeMe(this.domain);
-				this.ui.setLoading(false);
-				this.ui.handleHash();
-				this.changeConversation(this.conversation);
-				this.changedConversation();
-			}
-		}
-		else {
-			this.gotChannels = false;
-			this.gotPms = false;
-			this.gotMentions = false;
-			this.ui.setLoading(true);
-		}
-	}
-
-	isChannel(name) {
-		if (name) {
-			if (name.toString().length == 8) {
-				return true;
-			}
-		}
-		return false;
-	}
-
-	channelForID(id) {
-		return this.channels.filter(c => {
-			return c.id == id;
-		})[0];
-	}
-
-	channelForName(name) {
-		return this.channels.filter(c => {
-			return c.name == name;
-		})[0];
-	}
-
-	stakedForName(name) {
-		return this.staked.filter(c => {
-			return c.name == name;
-		})[0];
-	}
-
-	pmForID(id) {
-		return this.pms.filter(c => {
-			return c.id == id;
-		})[0];
-	}
-
-	pmWithUser(id) {
-		return this.pms.filter(c => {
-			return c.users.includes(id);
-		})[0];
-	}
-
-	otherUser(users) {
-		return users.filter(u => {
-			return u !== this.domain;
-		})[0];
-	}
-
-	userForID(id) {
-		if (this.users) {
-			return this.users.filter(u => {
-				return u.id == id;
-			})[0];
-		}
-		return false;
-	}
-
-	userForName(name, active=false) {
-		return this.users.filter(u => {
-			return (u.domain == name || this.ui.toUnicode(u.domain) == name) && !u.locked && !u.deleted;
-		})[0];
-	}
-
-	usersForConversation(id) {
-		if (this.channels) {
-			let conversation = this.channels.filter(c => {
-				return c.id == id;
-			})[0];
-
-			let users = this.users.filter(u => {
-				return !u.locked;
-			});
-			if (!conversation.public) {
-				users = this.users.filter(u => {
-					return !u.locked && u.tld == conversation.name || u.id == "n2sTWh5EZGI8xMQr";
-				});
-			}
-
-			return users;
-		}
-		return [];
-	}
-
-	changeConversation(id) {
-		let current = this.conversation;
-		let change = id;
-
-		if (!this.pmForID(id) && !this.channelForID(id)) {
-			id = false;
-		}
-
-		if (!id) {
-			change = this.channels[0].id;
-		}
-
-		if (current !== change) {
-			this.conversation = change;
-			localStorage.setItem("conversation", this.conversation);
-			this.changedConversation();
-		}
-	}
-
-	changedConversation() {
-		this.ui.closeMenusIfNeeded();
-
-		this.messages = [];
-		this.ui.clear("input");
-		this.ui.clear("messages");
-		this.ui.setInThePast(false);
-		this.ui.messagesLoading(true);
-		this.ui.emptyUserList();
-		this.ui.searchUsers(false);
-		this.ui.clearSelection();
-		this.ui.updateTypingView();
-		this.getMessages();
-
-		if (this.isChannel(this.conversation)) {
-			this.tab = "channels";
-		}
-		else {
-			this.tab = "pms";
-		}
-
-		this.ui.setConversationTab();
-
-		this.ui.setActiveConversation();
-		this.ui.markUnread(this.conversation, false);
-		this.ui.markMention(this.conversation, false);
-		this.ui.updateInputBar();
-
-		this.ui.showVideoIfNeeded();
-
-		this.seen[this.conversation] = this.time();
-		this.ws.send(`CHANGEDCONVERSATION ${this.conversation}`);
-	}
-
-	getMessage(id) {
-		let data = {
-			action: "getMessage",
-			domain: this.domain,
-			id: id
-		};
-
-		return this.api(data);
-	}
-
-	getMessages(options={}) {
-		if (this.loadingMessages) {
-			return;
-		}
-
-		this.loadingMessages = true;
-		
-		let data = {
-			conversation: this.conversation,
-		};
-		let merged = {...data,...options};
-
-		this.ws.send(`MESSAGES ${JSON.stringify(merged)}`);
-	}
-
-	async makeSecret(pm) {
-		let output = new Promise(resolve => {
-			let otherUser = this.otherUserFromPM(pm.id);
-			let otherKey = otherUser.pubkey;
-
-			this.e2ee.deriveKey(otherKey, this.keys.privateKeyJwk).then(key => {
-				otherUser.sharedkey = key;
-				resolve(key);
-			});
-		});
-
-		return await output;
-	}
-
-	async decryptedBody(conversation, message) {
-		let output = new Promise(resolve => {
-			let pm = this.pmForID(conversation);
-			let user = this.userForID(this.otherUser(pm.users));
-
-			this.e2ee.decryptMessage(message, user.sharedkey, conversation).then(decrypted => {
-				resolve(decrypted.trim());
-			});
-		});
-
-		return await output;
-	}
-
-	async decryptMessageIfNeeded(conversation, message) {
-		let body = new Promise(resolve => {
-			if (this.isChannel(conversation)) {
-				resolve(message.message);
-			}
-			else {
-				this.decryptedBody(conversation, message.message).then(decrypted => {
-					resolve(decrypted);
-				});
-			}
-		});
-
-		let replyBody = new Promise(resolve => {
-			if (message.p_message) {
-				if (this.isChannel(conversation)) {
-					resolve(message.p_message);
-				}
-				else {
-					this.decryptedBody(conversation, message.p_message).then(decrypted => {
-						resolve(decrypted);
-					});
-				}
-			}
-			else {
-				resolve();
-			}
-		});
-
-		let prepared = await Promise.all([body, replyBody]);
-		return prepared;
-	}
-
-	async encryptedBody(conversation, message) {
-		let output = new Promise(resolve => {
-			let pm = this.pmForID(conversation);
-			let user = this.userForID(this.otherUser(pm.users));
-
-			this.e2ee.encryptMessage(message, user.sharedkey, conversation).then(encrypted => {
-				resolve(encrypted.trim());
-			});
-		});
-
-		return await output;
-	}
-
-	async encryptMessageIfNeeded(conversation, message) {
-		let output = new Promise(resolve => {
-			if (this.isChannel(conversation)) {
-				resolve(message);
-			}
-			else {
-				this.encryptedBody(conversation, message).then(encrypted => {
-					resolve(encrypted);
-				});
-			}
-		});
-
-		return await output;
-	}
-
-	changeDomain(domain) {
-		this.domain = domain;
-		localStorage.setItem("domain", domain);
-
-		if (this.page == "chat") {
-			this.ready(false);
-			this.ws.send(`DOMAIN ${domain}`);
-		}
-	}
-
-	usersInMessage(message) {
-		let matches = this.regex(/\@(?<name>[^ \x00]+?)\//gm, message);
-		return matches;
-	}
-
-	channelsInMessage(message) {
-		let matches = this.regex(/\#(?<name>[^ \x00]+?)(?:\s|$)/gm, message);
-		return matches;
-	}
-
-	replaceCompletions(text) {
-		let output = text;
-
-		while (this.usersInMessage(output).length) {
-			let users = this.usersInMessage(output);
-			let result = users[0];
-
-			let name = result.groups.name;
-			let start = result.index;
-			let end = (start + name.length + 1 + 1);
-			
-			let match = this.users.filter(u => {
-				return this.ui.toUnicode(u.domain) == name && !u.locked;
-			});
-
-			let replace;
-			if (match.length) {
-				let id = match[0].id;
-				replace = `@${id}`;
-			}
-			else {
-				replace = `@\x00${name}/`;
-			}
-			output = this.replaceRange(output, start, end, replace);
-		}
-
-		while (this.channelsInMessage(output).length) {
-			let channels = this.channelsInMessage(output);
-			let result = channels[0];
-
-			let name = result.groups.name;
-			let start = result.index;
-			let end = (start + name.length + 1);
-			
-			let match = this.channels.filter(c => {
-				return this.ui.toUnicode(c.name) == name;
-			});
-
-			let replace;
-			if (match.length) {
-				let id = match[0].id;
-				replace = `@${id}`;
-			}
-			else {
-				replace = `#\x00${name}`;
-			}
-			output = this.replaceRange(output, start, end, replace);
-		}
-
-		return output;
-	}
-
-	sendTyping() {
-		let input = $("textarea#message").val();
-
-		if (!this.typing || !input || (input && input[0] == "/")) {
-			return;
-		}
-
-		let send = true;
-		if (this.typingSent) {
-			let diff = this.time() - this.typingSent;
-
-			if (diff < this.typingSendDelay) {
-				send = false;
-			}
-		}
-
-		if (send) {
-			this.typingSent = this.time();
-
-			let data = {
-				from: this.domain,
-				to: this.conversation
-			}
-
-			this.ws.send(`TYPING ${JSON.stringify(data)}`);
-		}
-	}
-
-	updateTypingStatus() {
-		if (this.lastTyped) {
-			if ((this.time() - this.lastTyped) > this.typingDelay) {
-				this.typing = false;
-				this.lastTyped = false;
-			}
-			else if ($("textarea#message").is(":focus") && $("textarea#message").val() !== "") {
-				this.typing = true;
-			}
-		}
-	}
-
-	sendMessage(conversation, message) {
-		if (!message.trim().length) {
-			return;
-		}
-
-		this.encryptMessageIfNeeded(conversation, message).then(encrypted => {
-			let data = {
-				conversation: conversation,
-				message: encrypted
-			}
-
-			if (this.replying) {
-				data.replying = this.replying.message;
-			}
-
-			this.typing = false;
-			this.ws.send(`MESSAGE ${JSON.stringify(data)}`);
-
-			this.replying = null;
-			this.ui.updateReplying();
-		});
-	}
-
-	async sendPayment(address, amount) {
-		const wallet = await bob3.connect();
-
-		if (!amount) {
-			return { message: "Please enter an amount." };
-		}
-
-		try {
-			const send = await wallet.send(address, amount);
-			return send;
-		}
-		catch (error) {
-			return error;
-		}
-	}
-
-	async upload(data, attachment) {
-		let output = new Promise(resolve => {
-			$.ajax({
-		        url: `${window.location.origin}/upload`,
-		        type: "POST",
-		        data: data,
-		        cache: false,
-		        contentType: false,
-		        processData: false,
-		        beforeSend: (e) => {},
-		        xhr: () => {
-		            let p = $.ajaxSettings.xhr();
-		            p.upload.onprogress = () => {}
-					return p;
-				},
-				success: (response) => {
-					let json = JSON.parse(response);
-
-					resolve(json);
-				}
-		    });
-		});
-
-		return await output;
-	}
-
-	deleteAttachment(id) {
-		let data = {
-			action: "deleteAttachment",
-			id: id
-		};
-
-		return this.api(data);
-	}
-
-	mentionsMe(message) {
-		if (message.includes(`@${this.domain}`)) {
-			return true;
-		}
-		return false;
-	}
-
-	replyingToMe(message) {
-		if (message.p_user && message.p_user == this.domain) {
-			return true;
-		}
-		return false;
-	}
+    constructor() {
+        window.hnschat = this;
+
+        try {
+            this.varo = new Varo();
+        } catch {}
+
+        this.mobile = false;
+
+        this.host = window.location.host;
+        this.hash = window.location.hash.substring(1);
+        this.page;
+        this.data;
+
+        this.ui = new ui(this);
+        this.ws = new ws(this);
+        this.listeners = new listeners(this);
+        this.e2ee = new e2ee();
+
+        this.streamURL = 'https://media.hns.chat/stream';
+        this.stream;
+
+        this.isActive = true;
+
+        this.keys;
+        this.session;
+        this.domain;
+        this.domains;
+        this.staked;
+        this.conversation;
+        this.settings;
+        this.messages = [];
+        this.seen = {};
+
+        this.users;
+
+        this.channels;
+        this.pms;
+
+        this.tab = 'channels';
+
+        this.timeFormat = 'g:i A';
+        this.dateFormat = 'F jS, Y';
+
+        this.gotChannels;
+        this.gotPms;
+        this.gotMentions;
+
+        this.loadingMessages;
+        this.replying;
+        this.queued = [];
+
+        this.typing;
+        this.typingSent;
+        this.typingDelay = 2;
+        this.typingSendDelay = 1;
+        this.lastTyped;
+        this.typers = {};
+
+        this.active = [];
+
+        this.avatars = {};
+
+        this.action = '\x01ACTION';
+
+        this.commands = ['me', 'shrug', 'slap'];
+
+        this.hasBob;
+
+        this.init();
+    }
+
+    varoLoaded() {
+        if (typeof this.varo !== 'undefined') {
+            return true;
+        }
+        return false;
+    }
+
+    getPage() {
+        let pathname = document.location.pathname;
+        let match = pathname.match(/\/(?<page>.+?)(?:\/(?<data>.+)|$)/);
+        if (match) {
+            let groups = match.groups;
+
+            if (groups.page) {
+                this.page = groups.page;
+            }
+            if (groups.data) {
+                this.data = groups.data;
+            }
+        } else {
+            this.page = 'chat';
+        }
+    }
+
+    async api(data) {
+        if (this.session) {
+            data.session = this.session;
+        }
+
+        let output = new Promise(function (resolve) {
+            $.post('/api', JSON.stringify(data), function (response) {
+                if (response) {
+                    let json = JSON.parse(response);
+                    resolve(json);
+                }
+            });
+        });
+
+        return await output;
+    }
+
+    time() {
+        return Math.floor(Date.now() / 1000);
+    }
+
+    handlePush(init = false) {
+        if (localStorage.handlePush) {
+            try {
+                let info = JSON.parse(localStorage.handlePush);
+
+                localStorage.setItem('domain', info.domain);
+                localStorage.setItem('conversation', info.conversation);
+
+                if (!init) {
+                    if (this.domain !== info.domain) {
+                        this.changeDomain(info.domain);
+                    }
+                    this.changeConversation(info.conversation);
+                }
+            } catch {}
+        }
+        localStorage.removeItem('handlePush');
+    }
+
+    autoCreateUser() {
+        // example url: http://localhost/id?name=yogibear&autocreate=true
+        this.ui.showSection('addDomain');
+        let urlParams = new URLSearchParams(window.location.search);
+        let name = urlParams.get('name');
+        let autocreate = urlParams.get('autocreate');
+        if (autocreate === 'true') {
+            let sld = name;
+            let tld = 'chrischannel';
+            let data = {
+                sld: sld,
+                tld: tld,
+            };
+            this.ws.send(`ADDSLD ${JSON.stringify(data)}`);
+            // this.ui.showSection('manageDomains');
+            window.location.href = '/';
+        }
+    }
+
+    async init() {
+        this.handlePush(true);
+
+        this.getPage();
+        switch (this.page) {
+            case 'sync':
+                this.loadSync();
+                break;
+
+            case 'buy':
+                break;
+
+            default:
+                try {
+                    this.keys = JSON.parse(localStorage.keys);
+                } catch {
+                    this.e2ee.generateKeys().then((r) => {
+                        this.keys = r;
+                        localStorage.setItem('keys', JSON.stringify(this.keys));
+                    });
+                }
+
+                if (this.hash) {
+                    localStorage.setItem('hash', this.hash);
+                    history.pushState(
+                        '',
+                        document.title,
+                        window.location.pathname + window.location.search
+                    );
+                } else {
+                    this.hash = localStorage.hash;
+                }
+
+                this.mobile = localStorage.mobile || false;
+
+                this.session = localStorage.session;
+                this.domain = localStorage.domain;
+                this.conversation = localStorage.conversation;
+
+                try {
+                    this.settings = JSON.parse(localStorage.settings);
+                    this.loadSettings();
+                } catch {
+                    this.settings = {};
+                }
+
+                this.firstLaunch = localStorage.firstLaunch;
+                if (!this.firstLaunch) {
+                    localStorage.setItem('firstLaunch', this.time());
+                }
+
+                await this.startSession();
+                await this.setPublicKey();
+                await this.ws.connect();
+                this.autoCreateUser();
+                break;
+        }
+
+        switch (this.page) {
+            case 'chat':
+                this.stream = new stream(this);
+                this.ui.setConversationTab();
+                this.ui.setupSync();
+                this.ui.setupNotifications();
+                break;
+        }
+
+        if (typeof bob3 != 'undefined') {
+            this.hasBob = true;
+            this.ui.hasBob();
+        }
+    }
+
+    loadSettings() {
+        Object.keys(this.settings).forEach((setting, k) => {
+            let value = this.settings[setting];
+            switch (setting) {
+                case 'chatDisplayMode':
+                    this.ui.chatDisplayMode(value);
+                    break;
+
+                default:
+                    this.ui.root.style.setProperty(`--${setting}`, value);
+                    break;
+            }
+        });
+    }
+
+    loadSync() {
+        let hash = this.hash;
+        let db64 = this.db64(hash);
+        let json = JSON.parse(db64);
+        this.session = json.session;
+        localStorage.setItem('session', this.session);
+
+        if (json.settings) {
+            this.settings = json.settings;
+            localStorage.setItem('settings', JSON.stringify(this.settings));
+        }
+
+        let data = {
+            action: 'getPublicKey',
+        };
+        this.api(data).then((r) => {
+            if (r.success) {
+                let pubkey = JSON.parse(r.pubkey);
+                this.e2ee
+                    .importKey(pubkey.x, pubkey.y, json.privkey)
+                    .then((privkey) => {
+                        this.keys = {
+                            privateKeyJwk: privkey,
+                            publicKeyJwk: pubkey,
+                        };
+
+                        localStorage.setItem('keys', JSON.stringify(this.keys));
+                        this.ui.openURL('/');
+                    });
+            }
+        });
+    }
+
+    db64(str) {
+        str = (str + '==='.slice((str.length + 3) % 4))
+            .replace(/-/g, '+')
+            .replace(/_/g, '/');
+        return atob(str);
+    }
+
+    b64(str) {
+        str.replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+        return btoa(str);
+    }
+
+    syncLink() {
+        let data = {
+            session: this.session,
+            privkey: this.keys.privateKeyJwk.d,
+            settings: this.settings,
+        };
+
+        let json = JSON.stringify(data);
+        let encoded = this.b64(json);
+        let link = 'https://' + this.host + '/sync#' + encoded;
+
+        return link;
+    }
+
+    regex(pattern, string) {
+        return [...string.matchAll(pattern)];
+    }
+
+    rtrim(str, chr) {
+        let rgxtrim = !chr ? new RegExp('\\s+$') : new RegExp(chr + '+$');
+        return str.replace(rgxtrim, '');
+    }
+
+    replaceRange(s, start, end, substitute) {
+        let before = s.substr(0, start);
+        let after = s.substr(end, s.length - end);
+
+        return before + substitute + after;
+    }
+
+    sorted(array, by) {
+        return array.sort((a, b) => a[by].localeCompare(b[by]));
+    }
+
+    isKey(e, key) {
+        if (this.key(e) == key) {
+            return true;
+        }
+        return false;
+    }
+
+    key(e) {
+        return e.which || e.keyCode;
+    }
+
+    keyName(e) {
+        return e.key;
+    }
+
+    setPublicKey() {
+        let data = {
+            action: 'setPublicKey',
+            pubkey: JSON.stringify(this.keys.publicKeyJwk),
+        };
+
+        return this.api(data);
+    }
+
+    async startSession() {
+        if (this.session) {
+            return;
+        }
+
+        let data = {
+            action: 'startSession',
+        };
+
+        return this.api(data).then((r) => {
+            this.session = r.session;
+            localStorage.setItem('session', r.session);
+        });
+    }
+
+    sendDomain() {
+        if (!this.domain) {
+            if (this.domains.length) {
+                this.domain = this.domains[0].id;
+                localStorage.setItem('domain', this.domain);
+            } else {
+                this.ui.openURL('/id');
+                return;
+            }
+        }
+        this.ws.send(`DOMAIN ${this.domain}`);
+    }
+
+    message(data) {
+        let message = data.toString();
+        let parsed = message.match(/(?<command>[A-Z]+)(\s(?<body>.+))?/);
+        this.handle(parsed.groups);
+    }
+
+    async handle(parsed) {
+        let command = parsed.command;
+        let body = parsed.body;
+        let push = false;
+
+        if (body) {
+            try {
+                body = JSON.parse(body);
+
+                for (var k in body) {
+                    try {
+                        body[k] = JSON.parse(body[k]);
+                    } catch {}
+
+                    for (var i in body[k]) {
+                        try {
+                            body[k][i] = JSON.parse(body[k][i]);
+                        } catch {}
+                    }
+                }
+            } catch {}
+        }
+
+        switch (command) {
+            case 'SUCCESS':
+                switch (body.type) {
+                    case 'ADDDOMAIN':
+                    case 'ADDSLD':
+                        this.ui.enableButton(body.type);
+                        this.ui.handleSuccess(body);
+                        break;
+
+                    case 'DELETEDOMAIN':
+                        this.ui.removeDomain(body.id);
+                        break;
+
+                    case 'VERIFYDOMAIN':
+                        this.ui.handleSuccess(body);
+                        break;
+
+                    case 'GETADDRESS':
+                        this.ui.paymentResponse(body);
+                        break;
+                }
+                break;
+
+            case 'ERROR':
+                switch (body.type) {
+                    case 'ADDDOMAIN':
+                        this.ui.errorResponse(body);
+                        break;
+
+                    case 'ADDSLD':
+                        this.ui.enableButton(body.type);
+                        this.ui.errorResponse(body);
+                        break;
+
+                    case 'MESSAGES':
+                        this.ui.setUserList();
+                        this.ui.messagesLoading(false);
+                        this.ui.setGatedView(body);
+                        this.ui.markEmptyIfNeeded();
+                        this.loadingMessages = false;
+                        break;
+
+                    case 'DOMAIN':
+                        this.domain = null;
+                        this.sendDomain();
+                        break;
+
+                    case 'PM':
+                        if (body.id) {
+                            let otherUser = this.otherUserFromPM(body.id);
+                            let queuedMessage = this.queuedMessage(
+                                otherUser.domain
+                            );
+                            if (queuedMessage) {
+                                this.ui.changeConversation(body.id);
+                                this.ui.close();
+                            }
+                        } else {
+                            this.ui.errorResponse(body);
+                        }
+                        break;
+
+                    case 'GETADDRESS':
+                        this.ui.paymentResponse(body);
+                        break;
+                }
+                break;
+
+            case 'IDENTIFIED':
+                if (this.page !== 'sync') {
+                    if (body.seen) {
+                        this.seen = body.seen;
+                    }
+                    this.ws.send('DOMAINS');
+                }
+                break;
+
+            case 'DOMAINS':
+                this.domains = body;
+                this.ui.domains(this.domains);
+
+                switch (this.page) {
+                    case 'chat':
+                        this.sendDomain();
+                        break;
+
+                    case 'id':
+                    case 'invite':
+                        this.ws.send(`STAKED`);
+                        break;
+                }
+                break;
+
+            case 'STAKED':
+                this.staked = body;
+                this.ui.stakedDomains(body);
+                break;
+
+            case 'DOMAIN':
+                this.ui.updateDomainSelect();
+                this.ws.send('USERS');
+                break;
+
+            case 'USERS':
+                $.each(body, (k, user) => {
+                    body[k].domain = body[k].domain.toString();
+                });
+                this.users = body;
+                this.ws.send(`PING`);
+                this.ws.send(`CHANNELS`);
+                this.ws.send(`PMS`);
+                break;
+
+            case 'USER':
+                this.users = this.users.filter((u) => {
+                    return u.id != body.id;
+                });
+
+                body.domain = body.domain.toString();
+                this.users.push(body);
+
+                if (body.id !== this.domain) {
+                    let pm = this.pmWithUser(body.id);
+                    if (pm) {
+                        this.makeSecret(pm);
+                    }
+                }
+
+                this.ui.setUserList();
+                this.ui.updateConversations();
+                break;
+
+            case 'CHANNELS':
+                this.ui.clear('channels');
+                this.channels = body;
+                if (this.channels.length) {
+                    let sorted = this.channels.sort((a, b) => {
+                        if ('activity' in a && !('activity' in b)) {
+                            return 1;
+                        }
+                        if ('activity' in b && !('activity' in a)) {
+                            return -1;
+                        }
+                        if (!('activity' in a) && !('activity' in b)) {
+                            return 0;
+                        }
+                        return a.activity - b.activity;
+                    });
+                    $.each(sorted.reverse(), (k, channel) => {
+                        this.ui.conversation('channels', channel);
+                    });
+                }
+                this.ui.updateConversations();
+                this.gotChannels = true;
+                this.ws.send(`MENTIONS`);
+                this.ready(true);
+                break;
+
+            case 'CHANNEL':
+                this.channels.push(body);
+                this.ui.conversation('channels', body);
+                this.ui.updateConversations();
+                break;
+
+            case 'PMS':
+                this.ui.clear('pms');
+                this.pms = body;
+                if (this.pms.length) {
+                    let sorted = this.pms.sort((a, b) => {
+                        return b.activity - a.activity;
+                    });
+                    $.each(sorted, (k, conversation) => {
+                        this.makeSecret(conversation).then((key) => {
+                            this.ui.conversation('pms', conversation);
+
+                            if (k == this.pms.length - 1) {
+                                this.ui.updateConversations();
+                                this.gotPms = true;
+                                this.ready(true);
+                            }
+                        });
+                    });
+                } else {
+                    this.ui.updateConversations();
+                    this.gotPms = true;
+                    this.ready(true);
+                }
+                break;
+
+            case 'PM':
+                this.pms.push(body);
+                this.makeSecret(body).then((key) => {
+                    this.ui.conversation('pms', body);
+
+                    let otherUser = this.otherUserFromPM(body.id);
+                    let queuedMessage = this.queuedMessage(otherUser.domain);
+                    if (queuedMessage) {
+                        this.ui.changeConversation(body.id);
+                        this.ui.close();
+                    }
+                });
+                break;
+
+            case 'MESSAGES':
+                this.ui.setUserList();
+                this.ui.insertMessages(body, true).then(() => {
+                    this.ui.messagesLoading(false);
+
+                    if (body.at) {
+                        this.ui.scrollToMessage(body.at);
+                    } else if (body.after) {
+                        this.ui.backInPresent(body);
+                    }
+
+                    if (!this.isChannel(this.conversation)) {
+                        let otherUser = this.otherUserFromPM(this.conversation);
+                        let queuedMessage = this.queuedMessage(
+                            otherUser.domain
+                        );
+                        if (queuedMessage) {
+                            this.queued = this.queued.filter((q) => {
+                                return q.domain !== queuedMessage.domain;
+                            });
+                            this.sendMessage(
+                                this.conversation,
+                                queuedMessage.message
+                            );
+                        }
+                    }
+                });
+                break;
+
+            case 'MESSAGE':
+            case 'NOTICE':
+                delete this.typers[body.user];
+
+                let c;
+                if (this.isChannel(body.conversation)) {
+                    c = this.channelForID(body.conversation);
+                } else {
+                    c = this.pmForID(body.conversation);
+                }
+                c.activity = body.time;
+
+                this.ui.updateConversations();
+                this.ui.moveConversationToTop(body.conversation);
+
+                await this.decryptMessageIfNeeded(body.conversation, body).then(
+                    (decrypted) => {
+                        body.message = decrypted[0];
+                        if (body.p_message) {
+                            body.p_message = decrypted[1];
+                        }
+
+                        if (typeof body.message == 'object') {
+                            if (body.message.message) {
+                                body.message.message =
+                                    body.message.message.toString();
+                            }
+                            body.message = JSON.stringify(body.message);
+                        }
+                        if (typeof body.p_message == 'object') {
+                            if (body.p_message.message) {
+                                body.p_message.message =
+                                    body.p_message.message.toString();
+                            }
+                            body.p_message = JSON.stringify(body.p_message);
+                        }
+
+                        body.message = body.message.toString();
+                        if (body.p_message) {
+                            body.p_message = body.p_message.toString();
+                        }
+
+                        if (
+                            !this.ui.inThePast &&
+                            body.conversation == this.conversation
+                        ) {
+                            let data = {
+                                messages: [body],
+                            };
+                            this.ui.insertMessages(data);
+                            this.seen[this.conversation] = this.time();
+
+                            if (!this.isActive) {
+                                if (this.isChannel(body.conversation)) {
+                                    if (this.mentionsMe(body.message)) {
+                                        push = 'mention';
+                                    } else if (this.replyingToMe(body)) {
+                                        push = 'reply';
+                                    }
+                                } else {
+                                    push = 'pm';
+                                }
+                            }
+                        } else {
+                            if (this.isChannel(body.conversation)) {
+                                if (this.mentionsMe(body.message)) {
+                                    this.ui.markMention(
+                                        body.conversation,
+                                        true
+                                    );
+                                    push = 'mention';
+                                } else if (this.replyingToMe(body)) {
+                                    push = 'reply';
+                                }
+                            } else {
+                                push = 'pm';
+                            }
+                        }
+
+                        if (push) {
+                            if (body.user !== this.domain) {
+                                let name;
+
+                                switch (push) {
+                                    case 'pm':
+                                        name = this.ui.toUnicode(
+                                            this.userForID(body.user).domain
+                                        );
+                                        break;
+
+                                    case 'mention':
+                                    case 'reply':
+                                        name = `${this.ui.toUnicode(
+                                            this.userForID(body.user).domain
+                                        )} - #${this.ui.toUnicode(c.name)}`;
+                                        break;
+                                }
+
+                                let subtitle = this.ui.messageSummary(
+                                    decrypted[0]
+                                );
+                                subtitle = this.ui.stripHTML(
+                                    this.ui.replaceIds(subtitle)
+                                );
+                                this.ui.sendNotification(
+                                    name,
+                                    subtitle,
+                                    body.conversation
+                                );
+                            }
+                        }
+                    }
+                );
+                break;
+
+            case 'DELETEMESSAGE':
+                this.ui.deleteMessage(body.id);
+                break;
+
+            case 'REACT':
+                if (body.conversation == this.conversation) {
+                    let message = this.messages.filter((m) => {
+                        return m.id == body.message;
+                    })[0];
+
+                    try {
+                        let json = JSON.parse(message.reactions);
+
+                        if (!Object.keys(json).includes(body.reaction)) {
+                            json[body.reaction] = [];
+                        }
+
+                        if (json[body.reaction].includes(body.user)) {
+                            let x = json[body.reaction].indexOf(body.user);
+                            delete json[body.reaction].splice(x, 1);
+
+                            if (!Object.keys(json[body.reaction]).length) {
+                                delete json[body.reaction];
+                            }
+                        } else {
+                            json[body.reaction].push(body.user);
+                        }
+
+                        message.reactions = JSON.stringify(json);
+                        this.ui.updateReactions(body.message);
+                        this.seen[this.conversation] = this.time();
+                    } catch {}
+                }
+                break;
+
+            case 'TYPING':
+                this.typers[body.from] = {
+                    to: body.to,
+                    time: this.time(),
+                };
+                break;
+
+            case 'MENTIONS':
+                this.ui.updateMentions(body);
+                this.gotMentions = true;
+                this.ready(true);
+                break;
+
+            case 'PONG':
+                this.updateActiveUsers(body.active);
+                //this.ui.checkVersion(body.version);
+                break;
+
+            case 'PINMESSAGE':
+                this.channelForID(body.conversation).pinned = body.id;
+                if (this.conversation == body.conversation) {
+                    this.ui.setPinnedMessage();
+                }
+                break;
+
+            case 'STARTVIDEO':
+                this.ui.muteAll();
+                this.channelForID(body.conversation).video = true;
+                this.channelForID(body.conversation).videoUsers = body.users;
+                this.ui.showVideoIfNeeded();
+                break;
+
+            case 'INVITEVIDEO':
+                this.channelForID(body.conversation).videoSpeakers =
+                    body.speakers;
+                this.ui.showVideoIfNeeded();
+                break;
+
+            case 'JOINVIDEO':
+                if (body.users) {
+                    this.channelForID(body.conversation).videoUsers =
+                        body.users;
+                }
+                if (body.watchers) {
+                    this.channelForID(body.conversation).videoWatchers =
+                        body.watchers;
+                }
+                if (body.speakers) {
+                    this.channelForID(body.conversation).videoSpeakers =
+                        body.speakers;
+                }
+                this.ui.showVideoIfNeeded();
+                break;
+
+            case 'VIEWVIDEO':
+                if (body.users) {
+                    this.channelForID(body.conversation).videoUsers =
+                        body.users;
+                }
+                if (body.watchers) {
+                    this.channelForID(body.conversation).videoWatchers =
+                        body.watchers;
+                    if (body.watchers.includes(this.domain)) {
+                        this.channelForID(body.conversation).watching = true;
+                    }
+                }
+                this.ui.showVideoIfNeeded();
+                break;
+
+            case 'LEAVEVIDEO':
+                if (body.users) {
+                    this.channelForID(body.conversation).videoUsers =
+                        body.users;
+                }
+                if (body.watchers) {
+                    this.channelForID(body.conversation).videoWatchers =
+                        body.watchers;
+                }
+                if (body.speakers) {
+                    this.channelForID(body.conversation).videoSpeakers =
+                        body.speakers;
+                }
+                this.ui.showVideoIfNeeded();
+                break;
+
+            case 'ENDVIDEO':
+                this.endVideo(body.conversation);
+                break;
+
+            case 'MUTEVIDEO':
+            case 'MUTEAUDIO':
+                let toggle;
+                let user = this.channelForID(body.conversation).videoUsers[
+                    body.user
+                ];
+                switch (command) {
+                    case 'MUTEVIDEO':
+                        toggle = 'toggleVideo';
+                        user.video = !user.video;
+                        break;
+
+                    case 'MUTEAUDIO':
+                        toggle = 'toggleAudio';
+                        user.audio = !user.audio;
+                        break;
+                }
+                this.ui.updateVideoUsers();
+                if (body.user == this.domain) {
+                    this.ui.setMute(toggle, -1);
+                }
+                break;
+
+            case 'CONNECTED':
+                if (this.userForID(body)) {
+                    this.userForID(body).active = true;
+                    this.ui.updateUserList();
+                    this.ui.updateConversations();
+                }
+                break;
+
+            case 'DISCONNECTED':
+                if (this.userForID(body)) {
+                    this.userForID(body).active = false;
+                    this.ui.updateUserList();
+                    this.ui.updateConversations();
+                }
+                break;
+        }
+    }
+
+    endAllVideo() {
+        try {
+            this.stream.close();
+            $.each(this.channels, (k, c) => {
+                this.endVideo(c.id);
+            });
+        } catch {}
+    }
+
+    endVideo(conversation) {
+        this.channelForID(conversation).videoUsers = {};
+        this.channelForID(conversation).videoWatchers = [];
+        this.channelForID(conversation).videoSpeakers = [];
+        this.channelForID(conversation).video = false;
+        this.channelForID(conversation).watching = false;
+        this.ui.showVideoIfNeeded();
+    }
+
+    currentVideoUsers() {
+        return this.channelForID(this.conversation).videoUsers;
+    }
+
+    updateActiveUsers(active) {
+        if (this.users) {
+            let current = this.active;
+            this.active = active;
+
+            current.forEach((u) => {
+                if (!active.includes(u)) {
+                    let user = this.userForID(u);
+                    user.active = false;
+                }
+            });
+
+            active.forEach((u) => {
+                let user = this.userForID(u);
+                user.active = true;
+            });
+
+            this.ui.updateUserList();
+            this.ui.updateConversations();
+        }
+    }
+
+    otherUserFromPM(id) {
+        let pm = this.pmForID(id);
+        let otherUserID = this.otherUser(pm.users);
+        let otherUser = this.userForID(otherUserID);
+        return otherUser;
+    }
+
+    queuedMessage(domain) {
+        return this.queued.filter((q) => {
+            return q.domain == domain;
+        })[0];
+    }
+
+    ready(bool) {
+        if (bool) {
+            if (this.gotChannels && this.gotPms && this.gotMentions) {
+                this.ui.changeMe(this.domain);
+                this.ui.setLoading(false);
+                this.ui.handleHash();
+                this.changeConversation(this.conversation);
+                this.changedConversation();
+            }
+        } else {
+            this.gotChannels = false;
+            this.gotPms = false;
+            this.gotMentions = false;
+            this.ui.setLoading(true);
+        }
+    }
+
+    isChannel(name) {
+        if (name) {
+            if (name.toString().length == 8) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    channelForID(id) {
+        return this.channels.filter((c) => {
+            return c.id == id;
+        })[0];
+    }
+
+    channelForName(name) {
+        return this.channels.filter((c) => {
+            return c.name == name;
+        })[0];
+    }
+
+    stakedForName(name) {
+        return this.staked.filter((c) => {
+            return c.name == name;
+        })[0];
+    }
+
+    pmForID(id) {
+        return this.pms.filter((c) => {
+            return c.id == id;
+        })[0];
+    }
+
+    pmWithUser(id) {
+        return this.pms.filter((c) => {
+            return c.users.includes(id);
+        })[0];
+    }
+
+    otherUser(users) {
+        return users.filter((u) => {
+            return u !== this.domain;
+        })[0];
+    }
+
+    userForID(id) {
+        if (this.users) {
+            return this.users.filter((u) => {
+                return u.id == id;
+            })[0];
+        }
+        return false;
+    }
+
+    userForName(name, active = false) {
+        return this.users.filter((u) => {
+            return (
+                (u.domain == name || this.ui.toUnicode(u.domain) == name) &&
+                !u.locked &&
+                !u.deleted
+            );
+        })[0];
+    }
+
+    usersForConversation(id) {
+        if (this.channels) {
+            let conversation = this.channels.filter((c) => {
+                return c.id == id;
+            })[0];
+
+            let users = this.users.filter((u) => {
+                return !u.locked;
+            });
+            if (!conversation.public) {
+                users = this.users.filter((u) => {
+                    return (
+                        (!u.locked && u.tld == conversation.name) ||
+                        u.id == 'n2sTWh5EZGI8xMQr'
+                    );
+                });
+            }
+
+            return users;
+        }
+        return [];
+    }
+
+    changeConversation(id) {
+        let current = this.conversation;
+        let change = id;
+
+        if (!this.pmForID(id) && !this.channelForID(id)) {
+            id = false;
+        }
+
+        if (!id) {
+            change = this.channels[0].id;
+        }
+
+        if (current !== change) {
+            this.conversation = change;
+            localStorage.setItem('conversation', this.conversation);
+            this.changedConversation();
+        }
+    }
+
+    changedConversation() {
+        this.ui.closeMenusIfNeeded();
+
+        this.messages = [];
+        this.ui.clear('input');
+        this.ui.clear('messages');
+        this.ui.setInThePast(false);
+        this.ui.messagesLoading(true);
+        this.ui.emptyUserList();
+        this.ui.searchUsers(false);
+        this.ui.clearSelection();
+        this.ui.updateTypingView();
+        this.getMessages();
+
+        if (this.isChannel(this.conversation)) {
+            this.tab = 'channels';
+        } else {
+            this.tab = 'pms';
+        }
+
+        this.ui.setConversationTab();
+
+        this.ui.setActiveConversation();
+        this.ui.markUnread(this.conversation, false);
+        this.ui.markMention(this.conversation, false);
+        this.ui.updateInputBar();
+
+        this.ui.showVideoIfNeeded();
+
+        this.seen[this.conversation] = this.time();
+        this.ws.send(`CHANGEDCONVERSATION ${this.conversation}`);
+    }
+
+    getMessage(id) {
+        let data = {
+            action: 'getMessage',
+            domain: this.domain,
+            id: id,
+        };
+
+        return this.api(data);
+    }
+
+    getMessages(options = {}) {
+        if (this.loadingMessages) {
+            return;
+        }
+
+        this.loadingMessages = true;
+
+        let data = {
+            conversation: this.conversation,
+        };
+        let merged = { ...data, ...options };
+
+        this.ws.send(`MESSAGES ${JSON.stringify(merged)}`);
+    }
+
+    async makeSecret(pm) {
+        let output = new Promise((resolve) => {
+            let otherUser = this.otherUserFromPM(pm.id);
+            let otherKey = otherUser.pubkey;
+
+            this.e2ee
+                .deriveKey(otherKey, this.keys.privateKeyJwk)
+                .then((key) => {
+                    otherUser.sharedkey = key;
+                    resolve(key);
+                });
+        });
+
+        return await output;
+    }
+
+    async decryptedBody(conversation, message) {
+        let output = new Promise((resolve) => {
+            let pm = this.pmForID(conversation);
+            let user = this.userForID(this.otherUser(pm.users));
+
+            this.e2ee
+                .decryptMessage(message, user.sharedkey, conversation)
+                .then((decrypted) => {
+                    resolve(decrypted.trim());
+                });
+        });
+
+        return await output;
+    }
+
+    async decryptMessageIfNeeded(conversation, message) {
+        let body = new Promise((resolve) => {
+            if (this.isChannel(conversation)) {
+                resolve(message.message);
+            } else {
+                this.decryptedBody(conversation, message.message).then(
+                    (decrypted) => {
+                        resolve(decrypted);
+                    }
+                );
+            }
+        });
+
+        let replyBody = new Promise((resolve) => {
+            if (message.p_message) {
+                if (this.isChannel(conversation)) {
+                    resolve(message.p_message);
+                } else {
+                    this.decryptedBody(conversation, message.p_message).then(
+                        (decrypted) => {
+                            resolve(decrypted);
+                        }
+                    );
+                }
+            } else {
+                resolve();
+            }
+        });
+
+        let prepared = await Promise.all([body, replyBody]);
+        return prepared;
+    }
+
+    async encryptedBody(conversation, message) {
+        let output = new Promise((resolve) => {
+            let pm = this.pmForID(conversation);
+            let user = this.userForID(this.otherUser(pm.users));
+
+            this.e2ee
+                .encryptMessage(message, user.sharedkey, conversation)
+                .then((encrypted) => {
+                    resolve(encrypted.trim());
+                });
+        });
+
+        return await output;
+    }
+
+    async encryptMessageIfNeeded(conversation, message) {
+        let output = new Promise((resolve) => {
+            if (this.isChannel(conversation)) {
+                resolve(message);
+            } else {
+                this.encryptedBody(conversation, message).then((encrypted) => {
+                    resolve(encrypted);
+                });
+            }
+        });
+
+        return await output;
+    }
+
+    changeDomain(domain) {
+        this.domain = domain;
+        localStorage.setItem('domain', domain);
+
+        if (this.page == 'chat') {
+            this.ready(false);
+            this.ws.send(`DOMAIN ${domain}`);
+        }
+    }
+
+    usersInMessage(message) {
+        let matches = this.regex(/\@(?<name>[^ \x00]+?)\//gm, message);
+        return matches;
+    }
+
+    channelsInMessage(message) {
+        let matches = this.regex(/\#(?<name>[^ \x00]+?)(?:\s|$)/gm, message);
+        return matches;
+    }
+
+    replaceCompletions(text) {
+        let output = text;
+
+        while (this.usersInMessage(output).length) {
+            let users = this.usersInMessage(output);
+            let result = users[0];
+
+            let name = result.groups.name;
+            let start = result.index;
+            let end = start + name.length + 1 + 1;
+
+            let match = this.users.filter((u) => {
+                return this.ui.toUnicode(u.domain) == name && !u.locked;
+            });
+
+            let replace;
+            if (match.length) {
+                let id = match[0].id;
+                replace = `@${id}`;
+            } else {
+                replace = `@\x00${name}/`;
+            }
+            output = this.replaceRange(output, start, end, replace);
+        }
+
+        while (this.channelsInMessage(output).length) {
+            let channels = this.channelsInMessage(output);
+            let result = channels[0];
+
+            let name = result.groups.name;
+            let start = result.index;
+            let end = start + name.length + 1;
+
+            let match = this.channels.filter((c) => {
+                return this.ui.toUnicode(c.name) == name;
+            });
+
+            let replace;
+            if (match.length) {
+                let id = match[0].id;
+                replace = `@${id}`;
+            } else {
+                replace = `#\x00${name}`;
+            }
+            output = this.replaceRange(output, start, end, replace);
+        }
+
+        return output;
+    }
+
+    sendTyping() {
+        let input = $('textarea#message').val();
+
+        if (!this.typing || !input || (input && input[0] == '/')) {
+            return;
+        }
+
+        let send = true;
+        if (this.typingSent) {
+            let diff = this.time() - this.typingSent;
+
+            if (diff < this.typingSendDelay) {
+                send = false;
+            }
+        }
+
+        if (send) {
+            this.typingSent = this.time();
+
+            let data = {
+                from: this.domain,
+                to: this.conversation,
+            };
+
+            this.ws.send(`TYPING ${JSON.stringify(data)}`);
+        }
+    }
+
+    updateTypingStatus() {
+        if (this.lastTyped) {
+            if (this.time() - this.lastTyped > this.typingDelay) {
+                this.typing = false;
+                this.lastTyped = false;
+            } else if (
+                $('textarea#message').is(':focus') &&
+                $('textarea#message').val() !== ''
+            ) {
+                this.typing = true;
+            }
+        }
+    }
+
+    sendMessage(conversation, message) {
+        if (!message.trim().length) {
+            return;
+        }
+
+        this.encryptMessageIfNeeded(conversation, message).then((encrypted) => {
+            let data = {
+                conversation: conversation,
+                message: encrypted,
+            };
+
+            if (this.replying) {
+                data.replying = this.replying.message;
+            }
+
+            this.typing = false;
+            this.ws.send(`MESSAGE ${JSON.stringify(data)}`);
+
+            this.replying = null;
+            this.ui.updateReplying();
+        });
+    }
+
+    async sendPayment(address, amount) {
+        const wallet = await bob3.connect();
+
+        if (!amount) {
+            return { message: 'Please enter an amount.' };
+        }
+
+        try {
+            const send = await wallet.send(address, amount);
+            return send;
+        } catch (error) {
+            return error;
+        }
+    }
+
+    async upload(data, attachment) {
+        let output = new Promise((resolve) => {
+            $.ajax({
+                url: `${window.location.origin}/upload`,
+                type: 'POST',
+                data: data,
+                cache: false,
+                contentType: false,
+                processData: false,
+                beforeSend: (e) => {},
+                xhr: () => {
+                    let p = $.ajaxSettings.xhr();
+                    p.upload.onprogress = () => {};
+                    return p;
+                },
+                success: (response) => {
+                    let json = JSON.parse(response);
+
+                    resolve(json);
+                },
+            });
+        });
+
+        return await output;
+    }
+
+    deleteAttachment(id) {
+        let data = {
+            action: 'deleteAttachment',
+            id: id,
+        };
+
+        return this.api(data);
+    }
+
+    mentionsMe(message) {
+        if (message.includes(`@${this.domain}`)) {
+            return true;
+        }
+        return false;
+    }
+
+    replyingToMe(message) {
+        if (message.p_user && message.p_user == this.domain) {
+            return true;
+        }
+        return false;
+    }
 }
 
 new HNSChat();

--- a/chat-client/assets/js/ui.js
+++ b/chat-client/assets/js/ui.js
@@ -1,328 +1,354 @@
 let { punycode } = await import(`./punycode.js?r=${revision}`);
 
 export class ui {
-	constructor(parent) {
-		this.parent = parent;
+    constructor(parent) {
+        this.parent = parent;
 
-		this.inThePast = false;
+        this.inThePast = false;
 
-		this.browser = this.getBrowser();
-		this.root = document.querySelector(':root');
-		this.css = getComputedStyle($("html")[0]);
-		this.version = $("body").data("version");
-		this.updateAvailable = false;
+        this.browser = this.getBrowser();
+        this.root = document.querySelector(':root');
+        this.css = getComputedStyle($('html')[0]);
+        this.version = $('body').data('version');
+        this.updateAvailable = false;
 
-		this.emojiCategories = {
-			"Search": [],
-			"People": ["Smileys & Emotion", "People & Body"],
-			"Nature": ["Animals & Nature"],
-			"Food": ["Food & Drink"],
-			"Activities": ["Activities"],
-			"Travel": ["Travel & Places"],
-			"Objects": ["Objects"],
-			"Symbols": ["Symbols"],
-			"Flags": ["Flags"]
-		}
+        this.emojiCategories = {
+            Search: [],
+            People: ['Smileys & Emotion', 'People & Body'],
+            Nature: ['Animals & Nature'],
+            Food: ['Food & Drink'],
+            Activities: ['Activities'],
+            Travel: ['Travel & Places'],
+            Objects: ['Objects'],
+            Symbols: ['Symbols'],
+            Flags: ['Flags'],
+        };
 
-		if (!/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)) {
-			$("body").addClass("desktop");
-		}
+        if (
+            !/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
+                navigator.userAgent
+            )
+        ) {
+            $('body').addClass('desktop');
+        }
 
-		this.preloadIcons();
-	}
+        this.preloadIcons();
+    }
 
-	async gotoMessage(message) {
-		let messageExists = $(`.messageRow[data-id=${message}]`).length;
-		if (messageExists) {
-			this.scrollToMessage(message);
-		}
-		else {
-			let msg = await this.parent.getMessage(message);
-			if (msg.message) {
-				this.setInThePast(true);
-				this.clear("messages");
-				this.messagesLoading(true);
+    async gotoMessage(message) {
+        let messageExists = $(`.messageRow[data-id=${message}]`).length;
+        if (messageExists) {
+            this.scrollToMessage(message);
+        } else {
+            let msg = await this.parent.getMessage(message);
+            if (msg.message) {
+                this.setInThePast(true);
+                this.clear('messages');
+                this.messagesLoading(true);
 
-				let options = {
-					at: message
-				}
-				this.parent.getMessages(options);
-			}
-			else {
-				return;
-			}
-		}
+                let options = {
+                    at: message,
+                };
+                this.parent.getMessages(options);
+            } else {
+                return;
+            }
+        }
 
-		setTimeout(() => {
-			this.highlightMessage(message);
-		}, 250);
-	}
+        setTimeout(() => {
+            this.highlightMessage(message);
+        }, 250);
+    }
 
-	setInThePast(bool) {
-		if (bool) {
-			this.inThePast = true;
-			$("#jumpToPresent").removeClass("hidden");
-		}
-		else {
-			this.inThePast = false;
-			$("#jumpToPresent").addClass("hidden");
-		}
-	}
+    setInThePast(bool) {
+        if (bool) {
+            this.inThePast = true;
+            $('#jumpToPresent').removeClass('hidden');
+        } else {
+            this.inThePast = false;
+            $('#jumpToPresent').addClass('hidden');
+        }
+    }
 
-	backInPresent(body) {
-		let lastMessage = $("#messages > .messageRow[data-id]").last();
-		let lastMessageID = lastMessage.data("id");
-		
-		if (body.after && lastMessageID == body.latestMessage) {
-			this.setInThePast(false);
-		}
-	}
+    backInPresent(body) {
+        let lastMessage = $('#messages > .messageRow[data-id]').last();
+        let lastMessageID = lastMessage.data('id');
 
-	fetchNewMessages() {
-		let lastMessage = $("#messages > .messageRow[data-id]").last();
-		let lastMessageID = lastMessage.data("id");
-		let lastMessageTime = lastMessage.data("time");
+        if (body.after && lastMessageID == body.latestMessage) {
+            this.setInThePast(false);
+        }
+    }
 
-		if (lastMessageID) {
-			let options = {
-				after: lastMessageID
-			}
-			this.parent.getMessages(options);
-		}
-	}
+    fetchNewMessages() {
+        let lastMessage = $('#messages > .messageRow[data-id]').last();
+        let lastMessageID = lastMessage.data('id');
+        let lastMessageTime = lastMessage.data('time');
 
-	getVariables() {
-		const variables = Array.from(document.styleSheets)
-		    .filter(styleSheet => {
-		        try { return styleSheet.cssRules; }
-		        catch(e) { console.warn(e); }
-		    })
-		    .map(styleSheet => Array.from(styleSheet.cssRules))
-		    .flat()
-		    .filter(cssRule => cssRule.selectorText === ':root')
-		    .map(cssRule => cssRule.cssText.split('{')[1].split('}')[0].trim().split(';'))
-		    .flat()
-		    .filter(text => text !== "")
-		    .map(text => text.split(':'))
-		    .map(parts => ({key: parts[0].trim(), value: parts[1].trim() }))
-		;
-		 return variables;
-	}
+        if (lastMessageID) {
+            let options = {
+                after: lastMessageID,
+            };
+            this.parent.getMessages(options);
+        }
+    }
 
-	preloadIcons() {
-		let variables = this.getVariables();
+    getVariables() {
+        const variables = Array.from(document.styleSheets)
+            .filter((styleSheet) => {
+                try {
+                    return styleSheet.cssRules;
+                } catch (e) {
+                    console.warn(e);
+                }
+            })
+            .map((styleSheet) => Array.from(styleSheet.cssRules))
+            .flat()
+            .filter((cssRule) => cssRule.selectorText === ':root')
+            .map((cssRule) =>
+                cssRule.cssText.split('{')[1].split('}')[0].trim().split(';')
+            )
+            .flat()
+            .filter((text) => text !== '')
+            .map((text) => text.split(':'))
+            .map((parts) => ({ key: parts[0].trim(), value: parts[1].trim() }));
+        return variables;
+    }
 
-		$.each(variables, (k, data) => {
-			let {key,value} = data;
-			
-			if (key.substring(key.length - 4) == "Icon") {
-				let match = value.match(/url\((?<asset>.+)\)/);
-				let asset = match.groups.asset.replaceAll("\\", "");
-				let link = `https://${this.parent.host}${asset}`;
-				new Image().src = link;
-			}
-		});
-	}
+    preloadIcons() {
+        let variables = this.getVariables();
 
-	setData(e, attr, val) {
-		$(e).data(attr, val);
-		$(e).attr(`data-${attr}`, val);
-	}
+        $.each(variables, (k, data) => {
+            let { key, value } = data;
 
-	setupSync() {
-		let link = this.parent.syncLink();
-		let popover = $(".popover[data-name=syncSession]");
-		let qr = popover.find("#qrcode");
-		let input = popover.find("input[name=syncLink]");
-		qr.empty();
-		qr.html('<div id="qrlogo"><img draggable="false" src="/assets/img/handshake"></div>');
-		input.val(link);
-		if (!qr.find("canvas").length) {
-			let qrcode = new QRCode(qr[0], {
-				text: link,
-				width: 250,
-				height: 250,
-				colorLight: this.css.getPropertyValue("--tertiaryBackground"),
-				colorDark: this.css.getPropertyValue("--primaryForeground"),
-				correctLevel: QRCode.CorrectLevel.L
-			});
-		}
-		qr.find("img").attr("draggable", "false");
-	}
+            if (key.substring(key.length - 4) == 'Icon') {
+                let match = value.match(/url\((?<asset>.+)\)/);
+                let asset = match.groups.asset.replaceAll('\\', '');
+                let link = `https://${this.parent.host}${asset}`;
+                new Image().src = link;
+            }
+        });
+    }
 
-	copyToClipboard(button) {
-		let field = button.parent().find("input")[0];
-		field.select();
-		field.setSelectionRange(0, 99999);
-		navigator.clipboard.writeText(field.value);
-		field.setSelectionRange(0, 0);
+    setData(e, attr, val) {
+        $(e).data(attr, val);
+        $(e).attr(`data-${attr}`, val);
+    }
 
-		button.addClass("copied");
-		setTimeout(() => {
-			button.removeClass("copied");
-		}, 1000);
-	}
+    setupSync() {
+        let link = this.parent.syncLink();
+        let popover = $('.popover[data-name=syncSession]');
+        let qr = popover.find('#qrcode');
+        let input = popover.find('input[name=syncLink]');
+        qr.empty();
+        qr.html(
+            '<div id="qrlogo"><img draggable="false" src="/assets/img/handshake"></div>'
+        );
+        input.val(link);
+        if (!qr.find('canvas').length) {
+            let qrcode = new QRCode(qr[0], {
+                text: link,
+                width: 250,
+                height: 250,
+                colorLight: this.css.getPropertyValue('--tertiaryBackground'),
+                colorDark: this.css.getPropertyValue('--primaryForeground'),
+                correctLevel: QRCode.CorrectLevel.L,
+            });
+        }
+        qr.find('img').attr('draggable', 'false');
+    }
 
-	sizeInput() {
-		let input = $("textarea#message");
-		input.css("height", "1px");
+    copyToClipboard(button) {
+        let field = button.parent().find('input')[0];
+        field.select();
+        field.setSelectionRange(0, 99999);
+        navigator.clipboard.writeText(field.value);
+        field.setSelectionRange(0, 0);
 
-		let height = input[0].scrollHeight;
+        button.addClass('copied');
+        setTimeout(() => {
+            button.removeClass('copied');
+        }, 1000);
+    }
 
-		if (height > 200) {
-			height = 200;
-		}
+    sizeInput() {
+        let input = $('textarea#message');
+        input.css('height', '1px');
 
-		input.css("height", height+"px");
-	}
+        let height = input[0].scrollHeight;
 
-	wordForPosition(text, position) {
-		let index = text.indexOf(position);
-		let preText = text.substr(0, position);
+        if (height > 200) {
+            height = 200;
+        }
 
-		if (preText.indexOf(" ") > 0) {
-			let words = preText.split(" ");
-			return (words.length - 1)
-		}
-		else {
-			return 0;
-		}
-	}
+        input.css('height', height + 'px');
+    }
 
-	updateCompletions() {
-		let options = [];
+    wordForPosition(text, position) {
+        let index = text.indexOf(position);
+        let preText = text.substr(0, position);
 
-		let closeIfNeeded = false;
+        if (preText.indexOf(' ') > 0) {
+            let words = preText.split(' ');
+            return words.length - 1;
+        } else {
+            return 0;
+        }
+    }
 
-		let input = $("textarea#message");
-		let text = input.val();
-		let words = text.split(" ");
-		let position = input[0].selectionStart;
+    updateCompletions() {
+        let options = [];
 
-		let word = words[this.wordForPosition(text, position)];
-		if (word.length > 1) {
-			$("#completions .body .list").empty();
+        let closeIfNeeded = false;
 
-			switch (word[0]) {
-				case "@":
-					$("#completions .title").html("Users");
+        let input = $('textarea#message');
+        let text = input.val();
+        let words = text.split(' ');
+        let position = input[0].selectionStart;
 
-					let users = this.parent.usersForConversation(this.parent.conversation);
-					options = users.filter(user => {
-						let match = Array.from(this.toUnicode(user.domain)).slice(0, Array.from(word).length - 1).join("").toLowerCase();
-						let search = word.toLowerCase();
+        let word = words[this.wordForPosition(text, position)];
+        if (word.length > 1) {
+            $('#completions .body .list').empty();
 
-						return !user.locked && "@"+match === search;
-					}).slice(0, 10);
+            switch (word[0]) {
+                case '@':
+                    $('#completions .title').html('Users');
 
-					$.each(options, (k, option) => {
-						let row = $(`#users .users tr[data-id="${option.id}"]`).clone();
-						$("#completions .body .list").append(row);
-					});
+                    let users = this.parent.usersForConversation(
+                        this.parent.conversation
+                    );
+                    options = users
+                        .filter((user) => {
+                            let match = Array.from(this.toUnicode(user.domain))
+                                .slice(0, Array.from(word).length - 1)
+                                .join('')
+                                .toLowerCase();
+                            let search = word.toLowerCase();
 
-					closeIfNeeded = true;
-					break;
+                            return !user.locked && '@' + match === search;
+                        })
+                        .slice(0, 10);
 
-				case "#":
-					$("#completions .title").html("Channels");
+                    $.each(options, (k, option) => {
+                        let row = $(
+                            `#users .users tr[data-id="${option.id}"]`
+                        ).clone();
+                        $('#completions .body .list').append(row);
+                    });
 
-					let channels = this.parent.channels;
-					options = channels.filter(channel => {
-						let match = Array.from(this.toUnicode(channel.name)).slice(0, Array.from(word).length - 1).join("").toLowerCase();
-						let search = word.toLowerCase();
+                    closeIfNeeded = true;
+                    break;
 
-						return "#"+match === search;
-					}).slice(0, 10);
+                case '#':
+                    $('#completions .title').html('Channels');
 
-					$.each(options, (k, option) => {
-						let row = $(`#conversations .channels tr[data-id="${option.id}"]`).clone();
-						$("#completions .body .list").append(row);
-					});
+                    let channels = this.parent.channels;
+                    options = channels
+                        .filter((channel) => {
+                            let match = Array.from(this.toUnicode(channel.name))
+                                .slice(0, Array.from(word).length - 1)
+                                .join('')
+                                .toLowerCase();
+                            let search = word.toLowerCase();
 
-					closeIfNeeded = true;
-					break;
-			}
-		}
-		else {
-			closeIfNeeded = true;
-		}
-		
-		if (options.length) {
-			$("#completions .list tr").first().addClass("active");
-			this.popover("completions");
-		}
-		else {
-			closeIfNeeded = true;
-		}
+                            return '#' + match === search;
+                        })
+                        .slice(0, 10);
 
-		if (closeIfNeeded) {
-			this.close();
-		}
-	}
+                    $.each(options, (k, option) => {
+                        let row = $(
+                            `#conversations .channels tr[data-id="${option.id}"]`
+                        ).clone();
+                        $('#completions .body .list').append(row);
+                    });
 
-	updateSelectedCompletion(key) {
-		if (!$("#completions.shown").length) {
-			return;
-		}
+                    closeIfNeeded = true;
+                    break;
+            }
+        } else {
+            closeIfNeeded = true;
+        }
 
-		let selected = $("#completions tr.active");
-		selected.removeClass("active");
+        if (options.length) {
+            $('#completions .list tr').first().addClass('active');
+            this.popover('completions');
+        } else {
+            closeIfNeeded = true;
+        }
 
-		let select;
-		let current = selected[0];
+        if (closeIfNeeded) {
+            this.close();
+        }
+    }
 
-		switch (key) {
-			case 38:
-				if (current.previousSibling) {
-					select = current.previousSibling;
-				}
-				else {
-					select = $("#completions .list").children().last();
-				}
-				break;
+    updateSelectedCompletion(key) {
+        if (!$('#completions.shown').length) {
+            return;
+        }
 
-			case 40:
-				if (current.nextSibling) {
-					select = current.nextSibling;
-				}
-				else {
-					select = $("#completions .list").children().first();
-				}
-				break;
-		}
+        let selected = $('#completions tr.active');
+        selected.removeClass('active');
 
-		$(select).addClass("active");
-	}
+        let select;
+        let current = selected[0];
 
-	domains(array) {
-		let domains = this.parent.sorted(array, "domain");
-        
-		switch (this.parent.page) {
-			case "chat":
-				$(".header .domains select").empty();
-				
-				$.each(domains, (k, i) => {
-					let verify = "";
-					if (i.locked) {
-						verify = " (Unverified)";
-					}
-					$(".header .domains select").append(`<option value="${i.id}">${this.toUnicode(i.domain)}/${verify}</option>`);
-				});
+        switch (key) {
+            case 38:
+                if (current.previousSibling) {
+                    select = current.previousSibling;
+                } else {
+                    select = $('#completions .list').children().last();
+                }
+                break;
 
-				$(".header .domains select").append(`<optgroup label="-----------------"></optgroup>`);
-				$(".header .domains select").append(`<option value="manageDomains">Manage Domains</option>`);
+            case 40:
+                if (current.nextSibling) {
+                    select = current.nextSibling;
+                } else {
+                    select = $('#completions .list').children().first();
+                }
+                break;
+        }
 
-				$(".header .domains select").val(this.parent.domain);
-				break;
+        $(select).addClass('active');
+    }
 
-			case "id":
-			case "invite":
-				if (!this.parent.varoLoaded() || this.parent.mobile) {
-					$(".varo").addClass("hidden");
-				}
-				$(".section#manageDomains .domains").empty();
-				$.each(domains, (k, i) => {
-					let html = $(`
+    domains(array) {
+        let domains = this.parent.sorted(array, 'domain');
+
+        switch (this.parent.page) {
+            case 'chat':
+                $('.header .domains select').empty();
+
+                $.each(domains, (k, i) => {
+                    let verify = '';
+                    if (i.locked) {
+                        verify = ' (Unverified)';
+                    }
+                    $('.header .domains select').append(
+                        `<option value="${i.id}">${this.toUnicode(
+                            i.domain
+                        )}/${verify}</option>`
+                    );
+                });
+
+                $('.header .domains select').append(
+                    `<optgroup label="-----------------"></optgroup>`
+                );
+                $('.header .domains select').append(
+                    `<option value="manageDomains">Manage Domains</option>`
+                );
+
+                $('.header .domains select').val(this.parent.domain);
+                break;
+
+            case 'id':
+            case 'invite':
+                if (!this.parent.varoLoaded() || this.parent.mobile) {
+                    $('.varo').addClass('hidden');
+                }
+                $('.section#manageDomains .domains').empty();
+                $.each(domains, (k, i) => {
+                    let html = $(`
 						<div class="domain" data-id="${i.id}" data-name="${i.domain}">
 							<div>${this.toUnicode(i.domain)}</div>
 							<div class="actions">
@@ -331,106 +357,122 @@ export class ui {
 						</div>
 					`);
 
-					if (i.locked) {
-						html.find(".actions").prepend(`<div class="action link" data-action="verifyDomain">Verify</div>`);
-					}
+                    if (i.locked) {
+                        html.find('.actions').prepend(
+                            `<div class="action link" data-action="verifyDomain">Verify</div>`
+                        );
+                    }
 
-					$(".section#manageDomains .domains").append(html);
-				});
+                    $('.section#manageDomains .domains').append(html);
+                });
 
-				if (domains.length) {
-					$(".section#manageDomains #startChatting").removeClass("hidden");
-				}
+                if (domains.length) {
+                    $('.section#manageDomains #startChatting').removeClass(
+                        'hidden'
+                    );
+                }
 
-				let urlParams = new URLSearchParams(window.location.search);
-				let autocreate = urlParams.get('autocreate');
-				if (this.parent.page !== "invite" && autocreate !== 'true') {
-					this.showSection("manageDomains");
-				}
-				break;
-		}
-	}
+                let urlParams = new URLSearchParams(window.location.search);
+                let autocreate = urlParams.get('autocreate');
+                if (this.parent.page !== 'invite' && autocreate !== 'true') {
+                    this.showSection('manageDomains');
+                }
+                break;
+        }
+    }
 
-	removeDomain(id) {
-		$(`.section#manageDomains .domains .domain[data-id=${id}]`).remove();
-	}
+    removeDomain(id) {
+        $(`.section#manageDomains .domains .domain[data-id=${id}]`).remove();
+    }
 
-	stakedDomains(domains) {
-		$(".section#addDomain select[name=tld]").empty();
+    stakedDomains(domains) {
+        $('.section#addDomain select[name=tld]').empty();
 
-		if (this.parent.page == "invite") {
-			$(".section[id=addDomain]").find(".button[data-action=addDomain]").addClass("hidden");
-			$(".section[id=addDomain]").find(".or").addClass("hidden");
+        if (this.parent.page == 'invite') {
+            $('.section[id=addDomain]')
+                .find('.button[data-action=addDomain]')
+                .addClass('hidden');
+            $('.section[id=addDomain]').find('.or').addClass('hidden');
 
-			let info = this.parent.stakedForName(this.parent.data);
-			if (info) {
-				$(".section#addDomain select[name=tld]").append(`<option value="${info.name}">${this.toUnicode(info.name)}</option>`);
-			}
-			else {
-				$(".section#addDomain").empty();
-				$(".section#addDomain").append(`<div class="error response">This invite code isn't valid.</div>`);
-			}
-			this.showSection("addDomain");
-		}
-		else {
-			$.each(domains, (k, i) => {
-				$(".section#addDomain select[name=tld]").append(`<option value="${i.name}">${this.toUnicode(i.name)}</option>`);
-			});
-		}
-	}
+            let info = this.parent.stakedForName(this.parent.data);
+            if (info) {
+                $('.section#addDomain select[name=tld]').append(
+                    `<option value="${info.name}">${this.toUnicode(
+                        info.name
+                    )}</option>`
+                );
+            } else {
+                $('.section#addDomain').empty();
+                $('.section#addDomain').append(
+                    `<div class="error response">This invite code isn't valid.</div>`
+                );
+            }
+            this.showSection('addDomain');
+        } else {
+            $.each(domains, (k, i) => {
+                $('.section#addDomain select[name=tld]').append(
+                    `<option value="${i.name}">${this.toUnicode(
+                        i.name
+                    )}</option>`
+                );
+            });
+        }
+    }
 
-	showSection(section) {
-		$(".section").find("input").val('');
-		$(".section").removeClass("shown");
-		$(`.section#${section}`).addClass("shown");
-	}
+    showSection(section) {
+        $('.section').find('input').val('');
+        $('.section').removeClass('shown');
+        $(`.section#${section}`).addClass('shown');
+    }
 
-	updateDomainSelect() {
-		$(".header .domains select").val(this.parent.domain);
-	}
+    updateDomainSelect() {
+        $('.header .domains select').val(this.parent.domain);
+    }
 
-	avatarFallback(string) {
-		let fallback;
+    avatarFallback(string) {
+        let fallback;
 
-		if (!this.parent.regex(/[a-zA-Z0-9]/g, string[0]).length) {
-			$.each(sortedEmojis, (k, e) => {
-				if (string.substring(0, e.emoji.length) == e.emoji) {
-					fallback = e.emoji;
-					return false;
-				}
-			});
-		}
+        if (!this.parent.regex(/[a-zA-Z0-9]/g, string[0]).length) {
+            $.each(sortedEmojis, (k, e) => {
+                if (string.substring(0, e.emoji.length) == e.emoji) {
+                    fallback = e.emoji;
+                    return false;
+                }
+            });
+        }
 
-		if (!fallback) {
-			fallback = String.fromCodePoint(string.codePointAt(0)).toUpperCase();
-		}
-		return fallback; 
-	}
+        if (!fallback) {
+            fallback = String.fromCodePoint(
+                string.codePointAt(0)
+            ).toUpperCase();
+        }
+        return fallback;
+    }
 
-	toUnicode(name) {
-		let puny = punycode.ToUnicode(name);
-		let zwj = nameToUnicode(puny);
-		return zwj;
-	}
+    toUnicode(name) {
+        let puny = punycode.ToUnicode(name);
+        let zwj = nameToUnicode(puny);
+        return zwj;
+    }
 
-	conversation(tab, data) {
-		let name = data.name;
-		let fallback = "#";
+    conversation(tab, data) {
+        let name = data.name;
+        let fallback = '#';
 
-		let user,domain;
-		if (tab == "pms") {
-			user = this.parent.otherUser(data.users);
-			domain = this.parent.userForID(user);
-			name = domain.domain;
-		}
+        let user, domain;
+        if (tab == 'pms') {
+            user = this.parent.otherUser(data.users);
+            domain = this.parent.userForID(user);
+            name = domain.domain;
+        }
 
-		name = this.toUnicode(name);
+        name = this.toUnicode(name);
 
-		if (tab == "pms") {
-			fallback = this.avatarFallback(name);
-		}
+        if (tab == 'pms') {
+            fallback = this.avatarFallback(name);
+        }
 
-		let html = $(`
+        let html = $(`
 			<tr data-id="${data.id}" data-type="${tab}">
 				<td class="avatar">
 					<div class="locked">
@@ -442,518 +484,561 @@ export class ui {
 			</tr>
 		`);
 
-		if (tab == "pms") {
-			let active = "";
-			if (domain.active) {
-				active = " active";
-			}
+        if (tab == 'pms') {
+            let active = '';
+            if (domain.active) {
+                active = ' active';
+            }
 
-			let avatar = $(`
+            let avatar = $(`
 				<div class="status${active}"></div>
 				<div class="favicon" data-id="${user}" data-domain="${name}"></div>
 			`);
-			html.find(".avatar").prepend(avatar);
-		}
+            html.find('.avatar').prepend(avatar);
+        }
 
-		$(`#conversations .${tab} table`).append(html);
+        $(`#conversations .${tab} table`).append(html);
 
-		this.updateAvatars();
-	}
+        this.updateAvatars();
+    }
 
-	updateConversations() {
-		let domain = this.parent.userForID(this.parent.domain);
+    updateConversations() {
+        let domain = this.parent.userForID(this.parent.domain);
 
-		$.each($("#conversations .sections tr"), (k, c) => {
-			let id = $(c).data("id");
+        $.each($('#conversations .sections tr'), (k, c) => {
+            let id = $(c).data('id');
 
-			let data;
-			if (this.parent.isChannel(id)) {
-				data = this.parent.channelForID(id);
+            let data;
+            if (this.parent.isChannel(id)) {
+                data = this.parent.channelForID(id);
 
-				if (!data.public && data.name !== domain.tld) {
-					$(c).addClass("locked");
-				}
-			}
-			else {
-				data = this.parent.pmForID(id);
+                if (!data.public && data.name !== domain.tld) {
+                    $(c).addClass('locked');
+                }
+            } else {
+                data = this.parent.pmForID(id);
 
-				if (data.activity) {
-					$(c).removeClass("hidden");
-				}
-				else {
-					$(c).addClass("hidden");
-				}
+                if (data.activity) {
+                    $(c).removeClass('hidden');
+                } else {
+                    $(c).addClass('hidden');
+                }
 
-				let otherUser = this.parent.otherUser(data.users);
-				let otherUserData = this.parent.userForID(otherUser);
+                let otherUser = this.parent.otherUser(data.users);
+                let otherUserData = this.parent.userForID(otherUser);
 
-				if (otherUserData.active) {
-					$(c).find(".avatar .status").addClass("active");
-				}
-				else {
-					$(c).find(".avatar .status").removeClass("active");
-				}
-				
-				if (otherUserData.locked || otherUserData.deleted) {
-					$(c).addClass("locked");
-				}
-				else if ($(c).hasClass("locked")) {
-					$(c).removeClass("locked");
+                if (otherUserData.active) {
+                    $(c).find('.avatar .status').addClass('active');
+                } else {
+                    $(c).find('.avatar .status').removeClass('active');
+                }
 
-					if (this.parent.conversation == id) {
-						this.parent.changeConversation(id);
-					}
-				}
-			}
+                if (otherUserData.locked || otherUserData.deleted) {
+                    $(c).addClass('locked');
+                } else if ($(c).hasClass('locked')) {
+                    $(c).removeClass('locked');
 
-			if (data.activity >= this.parent.firstLaunch) {
-				if (data.id !== this.parent.conversation) {
-					this.markUnread(data.id, true);
-				}
-			}
+                    if (this.parent.conversation == id) {
+                        this.parent.changeConversation(id);
+                    }
+                }
+            }
 
-			if (this.parent.seen[data.id]) {
-				if (this.parent.seen[data.id] >= data.activity) {
-					this.markUnread(data.id, false);
-				}
-			}
-		});
-	}
+            if (data.activity >= this.parent.firstLaunch) {
+                if (data.id !== this.parent.conversation) {
+                    this.markUnread(data.id, true);
+                }
+            }
 
-	conversationStatus() {
-		let domain = this.parent.userForID(this.parent.domain);
+            if (this.parent.seen[data.id]) {
+                if (this.parent.seen[data.id] >= data.activity) {
+                    this.markUnread(data.id, false);
+                }
+            }
+        });
+    }
 
-		if (domain.locked) {
-			return "verify";
-		}
-		else if ($(`#conversations tr[data-id=${this.parent.conversation}]`).hasClass("locked")) {
-			if (this.parent.isChannel(this.parent.conversation)) {
-				return "permissions";
-			}
-			else {
-				let data = this.parent.pmForID(this.parent.conversation);
-				let otherUser = this.parent.otherUser(data.users);
-				let otherUserData = this.parent.userForID(otherUser);
-				
-				if (otherUserData.locked || otherUserData.deleted) {
-					return "user";
-				}
-			}
-		}
+    conversationStatus() {
+        let domain = this.parent.userForID(this.parent.domain);
 
-		return true;
-	}
+        if (domain.locked) {
+            return 'verify';
+        } else if (
+            $(
+                `#conversations tr[data-id=${this.parent.conversation}]`
+            ).hasClass('locked')
+        ) {
+            if (this.parent.isChannel(this.parent.conversation)) {
+                return 'permissions';
+            } else {
+                let data = this.parent.pmForID(this.parent.conversation);
+                let otherUser = this.parent.otherUser(data.users);
+                let otherUserData = this.parent.userForID(otherUser);
 
-	updateInputBar() {
-		$("body").removeClass("unverified");
+                if (otherUserData.locked || otherUserData.deleted) {
+                    return 'user';
+                }
+            }
+        }
 
-		let status = this.conversationStatus();
+        return true;
+    }
 
-		switch (status) {
-			case "user":
-			case "verify":
-			case "permissions":
-				$(".inputHolder").addClass("locked");
-				break;
+    updateInputBar() {
+        $('body').removeClass('unverified');
 
-			default:
-				$(".inputHolder").removeClass("locked");
-				break;
-		}
+        let status = this.conversationStatus();
 
-		switch (status) {
-			case "user":
-				$(".inputHolder .locked").html("This user isn't available.");
-				break;
+        switch (status) {
+            case 'user':
+            case 'verify':
+            case 'permissions':
+                $('.inputHolder').addClass('locked');
+                break;
 
-			case "verify":
-				$("body").addClass("unverified");
-				$(".inputHolder .locked").html("Re-verify your name to chat.");
-				break;
+            default:
+                $('.inputHolder').removeClass('locked');
+                break;
+        }
 
-			case "permissions":
-				$(".inputHolder .locked").html("You don't have permissions to chat here.");
-				break;
-		}
-	}
+        switch (status) {
+            case 'user':
+                $('.inputHolder .locked').html("This user isn't available.");
+                break;
 
-	setConversationTab() {
-		$("#conversations .tabs .tab").removeClass("active");
-		$(`#conversations .tabs .tab[data-tab=${this.parent.tab}]`).addClass("active");
+            case 'verify':
+                $('body').addClass('unverified');
+                $('.inputHolder .locked').html('Re-verify your name to chat.');
+                break;
 
-		$(`#conversations .sections .section`).removeClass("shown");
-		$(`#conversations .sections .section.${this.parent.tab}`).addClass("shown");
-	}
+            case 'permissions':
+                $('.inputHolder .locked').html(
+                    "You don't have permissions to chat here."
+                );
+                break;
+        }
+    }
 
-	setActiveConversation() {
-		this.setData($("#holder"), "type", this.parent.tab);
+    setConversationTab() {
+        $('#conversations .tabs .tab').removeClass('active');
+        $(`#conversations .tabs .tab[data-tab=${this.parent.tab}]`).addClass(
+            'active'
+        );
 
-		$("#conversations tr").removeClass("active");
-		$(`#conversations tr[data-id=${this.parent.conversation}]`).addClass("active");
+        $(`#conversations .sections .section`).removeClass('shown');
+        $(`#conversations .sections .section.${this.parent.tab}`).addClass(
+            'shown'
+        );
+    }
 
-		$(".messageHeader table").empty();
-		$(".messageHeader table").append($(`#conversations tr.active`).clone());
-		$(".messageHeader table tr").removeClass("hidden");
+    setActiveConversation() {
+        this.setData($('#holder'), 'type', this.parent.tab);
 
-		this.setPinnedMessage();
-		this.updateAvatars();
-	}
+        $('#conversations tr').removeClass('active');
+        $(`#conversations tr[data-id=${this.parent.conversation}]`).addClass(
+            'active'
+        );
 
-	async setPinnedMessage() {
-		$(".pinnedMessage .delete").addClass("hidden");
-		$(".pinnedMessage").removeClass("shown");
+        $('.messageHeader table').empty();
+        $('.messageHeader table').append($(`#conversations tr.active`).clone());
+        $('.messageHeader table tr').removeClass('hidden');
 
-		let output = new Promise(resolve => {
-			if (!this.parent.isChannel(this.parent.conversation)) {
-				resolve();
-			}
+        this.setPinnedMessage();
+        this.updateAvatars();
+    }
 
-			let channelData = this.parent.channelForID(this.parent.conversation);
-			if (channelData.pinned) {
-				this.parent.getMessage(channelData.pinned).then(r => {
-					if (r.message) {
-						let message;
+    async setPinnedMessage() {
+        $('.pinnedMessage .delete').addClass('hidden');
+        $('.pinnedMessage').removeClass('shown');
 
-						let decoded = he.decode(he.decode(r.message));
-						try {
-							let msg = JSON.parse(decoded);
-							message = msg.message;
-						}
-						catch {
-							message = decoded;
-						}
-						resolve(message);
-					}
-					else {
-						resolve();
-					}
-				});
-			}
-			else {
-				resolve();
-			}
-		});
+        let output = new Promise((resolve) => {
+            if (!this.parent.isChannel(this.parent.conversation)) {
+                resolve();
+            }
 
-		let message = await output;
-		if (message && message.length) {
-			$(".pinnedMessage .message").html(message);
+            let channelData = this.parent.channelForID(
+                this.parent.conversation
+            );
+            if (channelData.pinned) {
+                this.parent.getMessage(channelData.pinned).then((r) => {
+                    if (r.message) {
+                        let message;
 
-			if (this.parent.isChannel(this.parent.conversation)) {
-				let me = this.parent.userForID(this.parent.domain);
-				let channel = this.parent.channelForID(this.parent.conversation);
+                        let decoded = he.decode(he.decode(r.message));
+                        try {
+                            let msg = JSON.parse(decoded);
+                            message = msg.message;
+                        } catch {
+                            message = decoded;
+                        }
+                        resolve(message);
+                    } else {
+                        resolve();
+                    }
+                });
+            } else {
+                resolve();
+            }
+        });
 
-				if (this.isAdmin(channel, me)) {
-					$(".pinnedMessage .delete").removeClass("hidden");
-				}
-			}
+        let message = await output;
+        if (message && message.length) {
+            $('.pinnedMessage .message').html(message);
 
-			this.linkify($(".pinnedMessage .message"));
-			$(".pinnedMessage").addClass("shown");
-		}
-	}
+            if (this.parent.isChannel(this.parent.conversation)) {
+                let me = this.parent.userForID(this.parent.domain);
+                let channel = this.parent.channelForID(
+                    this.parent.conversation
+                );
 
-	isAdmin(channel, user) {
-		if ((channel.tldadmin && channel.name == user.domain) || user.admin || channel.admins.includes(user.id)) {
-			return true;
-		}
-		return false;
-	}
+                if (this.isAdmin(channel, me)) {
+                    $('.pinnedMessage .delete').removeClass('hidden');
+                }
+            }
 
-	markUnread(conversation, bool) {
-		if (bool) {
-			if (!$(`#conversations tr[data-id=${conversation}]`).hasClass("locked") && conversation !== this.parent.conversation) {
-				$(`#conversations tr[data-id=${conversation}]`).addClass("unread");
-			}
-		}
-		else {
-			$(`#conversations tr[data-id=${conversation}]`).removeClass("unread");
-		}
+            this.linkify($('.pinnedMessage .message'));
+            $('.pinnedMessage').addClass('shown');
+        }
+    }
 
-		this.updateNotifications();
-	}
+    isAdmin(channel, user) {
+        if (
+            (channel.tldadmin && channel.name == user.domain) ||
+            user.admin ||
+            channel.admins.includes(user.id)
+        ) {
+            return true;
+        }
+        return false;
+    }
 
-	markMention(conversation, bool) {
-		if (bool) {
-			if (!$(`#conversations tr[data-id=${conversation}]`).hasClass("locked") && conversation !== this.parent.conversation) {
-				$(`#conversations tr[data-id=${conversation}]`).addClass("mentions");
-			}
-		}
-		else {
-			$(`#conversations tr[data-id=${conversation}]`).removeClass("mentions");
-		}
+    markUnread(conversation, bool) {
+        if (bool) {
+            if (
+                !$(`#conversations tr[data-id=${conversation}]`).hasClass(
+                    'locked'
+                ) &&
+                conversation !== this.parent.conversation
+            ) {
+                $(`#conversations tr[data-id=${conversation}]`).addClass(
+                    'unread'
+                );
+            }
+        } else {
+            $(`#conversations tr[data-id=${conversation}]`).removeClass(
+                'unread'
+            );
+        }
 
-		this.updateNotifications();
-	}
+        this.updateNotifications();
+    }
 
-	updateNotifications() {
-		if ($("#conversations .pms tr.unread").length) {
-			$("#conversations .tab[data-tab=pms]").addClass("notification");
-		}
-		else {
-			$("#conversations .tab[data-tab=pms]").removeClass("notification");
-		}
+    markMention(conversation, bool) {
+        if (bool) {
+            if (
+                !$(`#conversations tr[data-id=${conversation}]`).hasClass(
+                    'locked'
+                ) &&
+                conversation !== this.parent.conversation
+            ) {
+                $(`#conversations tr[data-id=${conversation}]`).addClass(
+                    'mentions'
+                );
+            }
+        } else {
+            $(`#conversations tr[data-id=${conversation}]`).removeClass(
+                'mentions'
+            );
+        }
 
-		if ($("#conversations .channels tr.mentions").length) {
-			$("#conversations .tab[data-tab=channels]").addClass("notification");
-		}
-		else {
-			$("#conversations .tab[data-tab=channels]").removeClass("notification");
-		}
+        this.updateNotifications();
+    }
 
-		if ($("#conversations .tab.notification").length) {
-			$(".header .left").addClass("notification");
-		}
-		else {
-			$(".header .left").removeClass("notification");
-		}
-	}
+    updateNotifications() {
+        if ($('#conversations .pms tr.unread').length) {
+            $('#conversations .tab[data-tab=pms]').addClass('notification');
+        } else {
+            $('#conversations .tab[data-tab=pms]').removeClass('notification');
+        }
 
-	setLoading(bool) {
-		if (bool) {
-			$(".connecting").removeClass("hidden");
-		}
-		else {
-			$(".connecting").addClass("hidden");
-		}
-	}
+        if ($('#conversations .channels tr.mentions').length) {
+            $('#conversations .tab[data-tab=channels]').addClass(
+                'notification'
+            );
+        } else {
+            $('#conversations .tab[data-tab=channels]').removeClass(
+                'notification'
+            );
+        }
 
-	clear(type) {
-		switch (type) {
-			case "channels":
-			case "pms":
-				$(`#conversations .${type} table`).empty();
-				break;
+        if ($('#conversations .tab.notification').length) {
+            $('.header .left').addClass('notification');
+        } else {
+            $('.header .left').removeClass('notification');
+        }
+    }
 
-			case "messages":
-				$("#messages").empty();
-				$(".needSLD").remove();
-				break;
+    setLoading(bool) {
+        if (bool) {
+            $('.connecting').removeClass('hidden');
+        } else {
+            $('.connecting').addClass('hidden');
+        }
+    }
 
-			case "input":
-				$("textarea#message").val('');
-				break;
-		}
-	}
+    clear(type) {
+        switch (type) {
+            case 'channels':
+            case 'pms':
+                $(`#conversations .${type} table`).empty();
+                break;
 
-	setGatedView(data) {
-		let channel = this.parent.channelForID(this.parent.conversation);
-		let message = `#${this.toUnicode(channel.name)} is a private community for owners of a .${this.toUnicode(channel.name)} only.`;
+            case 'messages':
+                $('#messages').empty();
+                $('.needSLD').remove();
+                break;
 
-		let names = this.parent.domains.filter(d => {
-			return d.tld == channel.name;
-		});
+            case 'input':
+                $('textarea#message').val('');
+                break;
+        }
+    }
 
-		let html = $(`
+    setGatedView(data) {
+        let channel = this.parent.channelForID(this.parent.conversation);
+        let message = `#${this.toUnicode(
+            channel.name
+        )} is a private community for owners of a .${this.toUnicode(
+            channel.name
+        )} only.`;
+
+        let names = this.parent.domains.filter((d) => {
+            return d.tld == channel.name;
+        });
+
+        let html = $(`
 			<div class="needSLD">
 				<span>${message}</span>
 			</div>
 		`);
-		switch (data.resolution) {
-			case "purchase":
-				html.append($(`
-					<div class="button" data-action="purchaseSLD" data-link="${data.link}">Purchase a .${this.toUnicode(channel.name)}</div>
-				`));
-				break;
+        switch (data.resolution) {
+            case 'purchase':
+                html.append(
+                    $(`
+					<div class="button" data-action="purchaseSLD" data-link="${
+                        data.link
+                    }">Purchase a .${this.toUnicode(channel.name)}</div>
+				`)
+                );
+                break;
 
-			case "create":
-				html.append($(`
-					<div class="button" data-action="createSLD" data-tld="${channel.name}">Create a free .${this.toUnicode(channel.name)}</div>
-				`));
-				break;
+            case 'create':
+                html.append(
+                    $(`
+					<div class="button" data-action="createSLD" data-tld="${
+                        channel.name
+                    }">Create a free .${this.toUnicode(channel.name)}</div>
+				`)
+                );
+                break;
 
-			default:
-				break;
-		}
+            default:
+                break;
+        }
 
-		names.forEach(name => {
-			html.append($(`
-				<div class="button" data-action="switchName" data-id="${name.id}">Switch to ${this.toUnicode(name.domain)}</div>
-			`));
-		});
+        names.forEach((name) => {
+            html.append(
+                $(`
+				<div class="button" data-action="switchName" data-id="${
+                    name.id
+                }">Switch to ${this.toUnicode(name.domain)}</div>
+			`)
+            );
+        });
 
-		$("#messageHolder").append(html);
-	}
+        $('#messageHolder').append(html);
+    }
 
-	emptyUserList() {
-		$("#users #count").html('');
-		$("#users .users table").empty();
-	}
+    emptyUserList() {
+        $('#users #count').html('');
+        $('#users .users table').empty();
+    }
 
-	setUserList() {
-		if (!this.parent.isChannel(this.parent.conversation)) {
-			return;
-		}
+    setUserList() {
+        if (!this.parent.isChannel(this.parent.conversation)) {
+            return;
+        }
 
-		if ($("#users .group.searching.shown").length) {
-			return;
-		}
+        if ($('#users .group.searching.shown').length) {
+            return;
+        }
 
-		$("#users .users table").empty();
+        $('#users .users table').empty();
 
-		let users = this.parent.usersForConversation(this.parent.conversation);
-		let sorted = this.parent.sorted(users, "domain");
+        let users = this.parent.usersForConversation(this.parent.conversation);
+        let sorted = this.parent.sorted(users, 'domain');
 
-		let active = sorted.filter(u => {
-			return u.active;
-		});
+        let active = sorted.filter((u) => {
+            return u.active;
+        });
 
-		let inactive = sorted.filter(u => {
-			return !u.active;
-		});
+        let inactive = sorted.filter((u) => {
+            return !u.active;
+        });
 
-		$.each(active, (k, user) => {
-			this.addUserToUserlist(user);
-		});
+        $.each(active, (k, user) => {
+            this.addUserToUserlist(user);
+        });
 
-		$.each(inactive, (k, user) => {
-			this.addUserToUserlist(user);
-		});
+        $.each(inactive, (k, user) => {
+            this.addUserToUserlist(user);
+        });
 
-		this.updateAvatars();
+        this.updateAvatars();
 
-		$("#users #count").html(users.length.toLocaleString("en-US"));
-	}
+        $('#users #count').html(users.length.toLocaleString('en-US'));
+    }
 
-	updateUserList() {
-		if (!this.parent.isChannel(this.parent.conversation)) {
-			return;
-		}
-		
-		let users = this.parent.usersForConversation(this.parent.conversation);
-		let sorted = this.parent.sorted(users, "domain");
+    updateUserList() {
+        if (!this.parent.isChannel(this.parent.conversation)) {
+            return;
+        }
 
-		let active = sorted.filter(u => {
-			return u.active;
-		});
+        let users = this.parent.usersForConversation(this.parent.conversation);
+        let sorted = this.parent.sorted(users, 'domain');
 
-		let inactive = sorted.filter(u => {
-			return !u.active;
-		});
+        let active = sorted.filter((u) => {
+            return u.active;
+        });
 
-		$.each(users, (k, user) => {
-			let userEl = $(`#users .user[data-id=${user.id}]`);
-			let isActive = !userEl.hasClass("inactive");
-			if (user.active) {
-				if (!isActive) {
-					let position = active.indexOf(user) - 1;
-					let before = $($("#users .user").get(position));
-					userEl.remove();
-					userEl.removeClass("inactive");
-					userEl.find(".avatar .status").addClass("active");
-					if (position < 0) {
-						$("#users table").prepend(userEl);
-					}
-					else {
-						userEl.insertAfter(before);
-					}
-				}
-			}
-			else {
-				if (isActive) {
-					let position = inactive.indexOf(user) + active.length;
-					let before = $($("#users .user").get(position));
-					userEl.remove();
-					userEl.addClass("inactive");
-					userEl.find(".avatar .status").removeClass("active");
-					if (position < 0) {
-						$("#users table").prepend(userEl);
-					}
-					else {
-						userEl.insertAfter(before);
-					}
-				}
-			}
-		});
-	}
+        let inactive = sorted.filter((u) => {
+            return !u.active;
+        });
 
-	addUserToUserlist(user) {
-		let name = this.toUnicode(user.domain);
+        $.each(users, (k, user) => {
+            let userEl = $(`#users .user[data-id=${user.id}]`);
+            let isActive = !userEl.hasClass('inactive');
+            if (user.active) {
+                if (!isActive) {
+                    let position = active.indexOf(user) - 1;
+                    let before = $($('#users .user').get(position));
+                    userEl.remove();
+                    userEl.removeClass('inactive');
+                    userEl.find('.avatar .status').addClass('active');
+                    if (position < 0) {
+                        $('#users table').prepend(userEl);
+                    } else {
+                        userEl.insertAfter(before);
+                    }
+                }
+            } else {
+                if (isActive) {
+                    let position = inactive.indexOf(user) + active.length;
+                    let before = $($('#users .user').get(position));
+                    userEl.remove();
+                    userEl.addClass('inactive');
+                    userEl.find('.avatar .status').removeClass('active');
+                    if (position < 0) {
+                        $('#users table').prepend(userEl);
+                    } else {
+                        userEl.insertAfter(before);
+                    }
+                }
+            }
+        });
+    }
 
-		let html = $(`
+    addUserToUserlist(user) {
+        let name = this.toUnicode(user.domain);
+        let html = $(`
 			<tr class="user" data-id="${user.id}" data-name="${user.domain}">
-				${this.avatar("td", user.id, user.domain, true)}
+				${this.avatar('td', user.id, user.domain, true)}
 				<td class="title">${name}</td>
 			</tr>
 		`);
 
-		if (!user.active) {
-			html.addClass("inactive");
-		}
+        if (!user.active) {
+            html.addClass('inactive');
+        }
 
-		$("#users .users table").append(html);
-	}
+        $('#users .users table').append(html);
+    }
 
-	replaceSpecialMessage(message) {
-		if (message.substring(0, 12) == "&#x1;ACTION ") {
-			return message.substring(12);
-		}
-		return message;
-	}
+    getUserIdByDomain(domain) {
+        return this.parent.getUserIdByDomain(domain);
+    }
 
-	messageSummary(message) {
-		let decoded = message;
-		try {
-			decoded = JSON.parse(message);
-		}
-		catch {}
+    replaceSpecialMessage(message) {
+        if (message.substring(0, 12) == '&#x1;ACTION ') {
+            return message.substring(12);
+        }
+        return message;
+    }
 
-		if (decoded.payment) {
-			return "sent a payment";
-		}
-		else if (decoded.attachment) {
-			return "sent an attachment";
-		}
-		else if (decoded.action) {
-			return decoded.action;
-		}
-		else if (decoded.message) {
-			return decoded.message;
-		}
-		return decoded;
-	} 
+    messageSummary(message) {
+        let decoded = message;
+        try {
+            decoded = JSON.parse(message);
+        } catch {}
 
-	async insertMessages(data, decrypt=false) {
-		let messages = data.messages;
+        if (decoded.payment) {
+            return 'sent a payment';
+        } else if (decoded.attachment) {
+            return 'sent an attachment';
+        } else if (decoded.action) {
+            return decoded.action;
+        } else if (decoded.message) {
+            return decoded.message;
+        }
+        return decoded;
+    }
 
-		for (let i in messages) {
-			let message = messages[i];
+    async insertMessages(data, decrypt = false) {
+        let messages = data.messages;
 
-			if ($(`.messageRow[data-id=${message.id}]`).length) {
-				return;
-			}
+        for (let i in messages) {
+            let message = messages[i];
 
-			if (decrypt) {
-				await this.parent.decryptMessageIfNeeded(this.parent.conversation, message).then(decrypted => {
-					message.message = decrypted[0];
-					if (message.p_message) {
-						message.p_message = decrypted[1];
-					}
-				});
-			}
+            if ($(`.messageRow[data-id=${message.id}]`).length) {
+                return;
+            }
 
-			if (message.p_message) {
-				message.p_message = this.messageSummary(message.p_message);
-			}
+            if (decrypt) {
+                await this.parent
+                    .decryptMessageIfNeeded(this.parent.conversation, message)
+                    .then((decrypted) => {
+                        message.message = decrypted[0];
+                        if (message.p_message) {
+                            message.p_message = decrypted[1];
+                        }
+                    });
+            }
 
-			let user = this.parent.userForID(message.user).domain;
-			let messageBody = he.decode(he.decode(message.message));
-			messageBody = he.encode(messageBody);
-			
-			let isAction = false;
-			if (messageBody.substring(0, 12) == "&#x1;ACTION ") {
-				messageBody = messageBody.substring(12);
-				isAction = true;
-			}
+            if (message.p_message) {
+                message.p_message = this.messageSummary(message.p_message);
+            }
 
-			let isNotice = false;
-			let hasEffect = false;
-			let hasStyle = false;
+            let user = this.parent.userForID(message.user).domain;
+            let messageBody = he.decode(he.decode(message.message));
+            messageBody = he.encode(messageBody);
 
-			let html = $(`
-				<div class="messageRow" data-id="${message.id}" data-time="${message.time}" data-sender="${message.user}">
+            let isAction = false;
+            if (messageBody.substring(0, 12) == '&#x1;ACTION ') {
+                messageBody = messageBody.substring(12);
+                isAction = true;
+            }
+
+            let isNotice = false;
+            let hasEffect = false;
+            let hasStyle = false;
+
+            let html = $(`
+				<div class="messageRow" data-id="${message.id}" data-time="${
+                message.time
+            }" data-sender="${message.user}">
 					<div class="contents">
 						<div class="main">
-							${this.avatar("div", message.user, user)}
+							${this.avatar('div', message.user, user)}
 							<div class="user" data-id="${message.user}">${this.toUnicode(user)}</div>
 							<div class="holder msg">
 								<div class="message">
@@ -969,107 +1054,109 @@ export class ui {
 				</div>
 			`);
 
-			let decoded = he.decode(messageBody);
-			try {
-				let json = JSON.parse(he.decode(decoded));
+            let decoded = he.decode(messageBody);
+            try {
+                let json = JSON.parse(he.decode(decoded));
 
-				if (json.hnschat) {
-					if (json.attachment) {
-						let link;
-						try {
-							let url = new URL(json.attachment);
-							switch (url.host) {
-								case "media.tenor.com":
-								case "api.zora.co":
-									link = json.attachment;
-									break;
-							}
-						}
-						catch {
-							link = `https://${window.location.host}/uploads/${json.attachment}`;
-						}
+                if (json.hnschat) {
+                    if (json.attachment) {
+                        let link;
+                        try {
+                            let url = new URL(json.attachment);
+                            switch (url.host) {
+                                case 'media.tenor.com':
+                                case 'api.zora.co':
+                                    link = json.attachment;
+                                    break;
+                            }
+                        } catch {
+                            link = `https://${window.location.host}/uploads/${json.attachment}`;
+                        }
 
-						let image = $(`
+                        let image = $(`
 							<a href="${link}" target="_blank">
 								<img src="${link}" />
 							</a>
 						`);
-						html.find(".message").addClass("image");
-						html.find(".message .body").empty();
-						html.find(".message .body").append(image);
-					}
-					else if (json.payment) {
-						let link = `https://niami.io/tx/${json.payment}`;
-						let image = $(`
+                        html.find('.message').addClass('image');
+                        html.find('.message .body').empty();
+                        html.find('.message .body').append(image);
+                    } else if (json.payment) {
+                        let link = `https://niami.io/tx/${json.payment}`;
+                        let image = $(`
 							<a href="${link}" target="_blank">
 								<div class="imageHolder">
 									<img src="/assets/img/icon-512x512" />
-									<div class="amount">${this.parent.rtrim(json.amount.toLocaleString("en-US", { minimumFractionDigits: 6 }), "0")}</div>
+									<div class="amount">${this.parent.rtrim(
+                                        json.amount.toLocaleString('en-US', {
+                                            minimumFractionDigits: 6,
+                                        }),
+                                        '0'
+                                    )}</div>
 									<div class="txMessage"></div>
 								</div>
 							</a>
 						`);
-						html.find(".message").addClass("image payment");
-						html.find(".message .body").empty();
-						html.find(".message .body").append(image);
-					}
-					else if (json.action) {
-						messageBody = he.encode(json.action);
-						html.find(".message .body").html(messageBody);
-						isAction = true;
-					}
-					else if (json.message) {
-						messageBody = json.message.toString();
-						messageBody = he.encode(messageBody);
-						html.find(".message .body").html(messageBody);
-					}
+                        html.find('.message').addClass('image payment');
+                        html.find('.message .body').empty();
+                        html.find('.message .body').append(image);
+                    } else if (json.action) {
+                        messageBody = he.encode(json.action);
+                        html.find('.message .body').html(messageBody);
+                        isAction = true;
+                    } else if (json.message) {
+                        messageBody = json.message.toString();
+                        messageBody = he.encode(messageBody);
+                        html.find('.message .body').html(messageBody);
+                    }
 
-					if (json.effect) {
-						hasEffect = json.effect;
-					}
-					if (json.style) {
-						hasStyle = json.style;
-					}
-				}
-			}
-			catch (e) {
-				html.find(".message .body").html(messageBody);
-			}
+                    if (json.effect) {
+                        hasEffect = json.effect;
+                    }
+                    if (json.style) {
+                        hasStyle = json.style;
+                    }
+                }
+            } catch (e) {
+                html.find('.message .body').html(messageBody);
+            }
 
-			if (isAction) {
-				html.addClass("action");
-			}
-			
-			let firstThree = Array.from(messageBody.toString()).slice(0, 3);
-			let isEmojis = true;
-			$.each(firstThree, (k, char) => {
-				if (!this.isCharEmoji(char)) {
-					isEmojis = false;
-					return false;
-				}
-			});
-			if (isEmojis) {
-				html.addClass("emojis");
-			}
+            if (isAction) {
+                html.addClass('action');
+            }
 
-			let isDice = true;
-			let chars = Array.from(messageBody.toString());
-			$.each(chars, (k, char) => {
-				if (!["⚀","⚁","⚂","⚃","⚄","⚅"].includes(char)) {
-					isDice = false;
-					return false;
-				}
-			});
-			if (isDice) {
-				html.addClass("emojis dice");
-			}
+            let firstThree = Array.from(messageBody.toString()).slice(0, 3);
+            let isEmojis = true;
+            $.each(firstThree, (k, char) => {
+                if (!this.isCharEmoji(char)) {
+                    isEmojis = false;
+                    return false;
+                }
+            });
+            if (isEmojis) {
+                html.addClass('emojis');
+            }
 
-			if (hasStyle) {
-				this.setData(html, "style", hasStyle);
-			}
+            let isDice = true;
+            let chars = Array.from(messageBody.toString());
+            $.each(chars, (k, char) => {
+                if (!['⚀', '⚁', '⚂', '⚃', '⚄', '⚅'].includes(char)) {
+                    isDice = false;
+                    return false;
+                }
+            });
+            if (isDice) {
+                html.addClass('emojis dice');
+            }
 
-			let messageTime = new Date(message.time * 1000).format(this.parent.timeFormat);
-			let actions = $(`
+            if (hasStyle) {
+                this.setData(html, 'style', hasStyle);
+            }
+
+            let messageTime = new Date(message.time * 1000).format(
+                this.parent.timeFormat
+            );
+            let actions = $(`
 				<div class="hover">
 					<div class="time">${messageTime}</div>
 					<div class="actions">
@@ -1077,27 +1164,26 @@ export class ui {
 						<div class="action icon emoji" data-action="emojis"></div>
 					</div>
 				</div>
-			`)
+			`);
 
-			if (message.user == this.parent.domain) {
-				html.addClass("self");
+            if (message.user == this.parent.domain) {
+                html.addClass('self');
 
-				html.find(".holder.msg").prepend(actions);
-			}
-			else {
-				html.find(".holder.msg").append(actions);
-			}
+                html.find('.holder.msg').prepend(actions);
+            } else {
+                html.find('.holder.msg').append(actions);
+            }
 
-			if (this.parent.mentionsMe(message.message)) {
-				html.addClass("mention");
-			}
+            if (this.parent.mentionsMe(message.message)) {
+                html.addClass('mention');
+            }
 
-			if (message.notice) {
-				html.addClass("notice");
-			}
+            if (message.notice) {
+                html.addClass('notice');
+            }
 
-			if (message.replying) {
-				let reply = $(`
+            if (message.replying) {
+                let reply = $(`
 					<div class="reply" data-id="${message.replying}">
 						<div class="line"></div>
 						<div class="contents">
@@ -1107,493 +1193,552 @@ export class ui {
 					</div>
 				`);
 
-				if (message.p_user && message.p_message) {
-					let messageReplyBody = "";
-					if (message.p_message.length) {
-						messageReplyBody = he.encode(message.p_message);
-						messageReplyBody = this.replaceSpecialMessage(messageReplyBody);
-					}
+                if (message.p_user && message.p_message) {
+                    let messageReplyBody = '';
+                    if (message.p_message.length) {
+                        messageReplyBody = he.encode(message.p_message);
+                        messageReplyBody =
+                            this.replaceSpecialMessage(messageReplyBody);
+                    }
 
-					let p_user = this.parent.userForID(message.p_user).domain;
+                    let p_user = this.parent.userForID(message.p_user).domain;
 
-					this.setData(reply.find(".user"), "id", message.p_user);
-					reply.find(".user").html(this.toUnicode(p_user));
-					reply.find(".body").html(messageReplyBody);
+                    this.setData(reply.find('.user'), 'id', message.p_user);
+                    reply.find('.user').html(this.toUnicode(p_user));
+                    reply.find('.body').html(messageReplyBody);
 
-					if (message.p_user == this.parent.domain) {
-						html.addClass("mention");
-					}
-				}
-				else {
-					reply.find(".user").remove();
-					reply.find(".body").html("Original message was deleted.");
-				}
+                    if (message.p_user == this.parent.domain) {
+                        html.addClass('mention');
+                    }
+                } else {
+                    reply.find('.user').remove();
+                    reply.find('.body').html('Original message was deleted.');
+                }
 
-				html.addClass("replying");
-				html.prepend(reply);
-			}
+                html.addClass('replying');
+                html.prepend(reply);
+            }
 
-			if (hasEffect) {
-				let effect = $(`<div class="messageEffect action link" data-action="replayEffect" data-effect="${hasEffect}"><div class="icon replay"></div>Replay</div>`);
-				html.find("> .contents").append(effect);
-			}
+            if (hasEffect) {
+                let effect = $(
+                    `<div class="messageEffect action link" data-action="replayEffect" data-effect="${hasEffect}"><div class="icon replay"></div>Replay</div>`
+                );
+                html.find('> .contents').append(effect);
+            }
 
-			if (!message.reactions) {
-				message.reactions = JSON.stringify({});
-			}
+            if (!message.reactions) {
+                message.reactions = JSON.stringify({});
+            }
 
-			if (data.before || data.at) {
-				this.parent.messages.unshift(message);
-				$("#messages").prepend(html);
-			}
-			else {
-				this.parent.messages.push(message);
-				$("#messages").append(html);
-				this.fixScroll();	
-			}
+            if (data.before || data.at) {
+                this.parent.messages.unshift(message);
+                $('#messages').prepend(html);
+            } else {
+                this.parent.messages.push(message);
+                $('#messages').append(html);
+                this.fixScroll();
+            }
 
-			if (!decrypt && hasEffect) {
-				this.handleEffect(hasEffect);
-			}
+            if (!decrypt && hasEffect) {
+                this.handleEffect(hasEffect);
+            }
 
-			this.updateReactions(message.id);
-			this.stylizeMessage(html);
-			this.updateAvatars();
-		}
+            this.updateReactions(message.id);
+            this.stylizeMessage(html);
+            this.updateAvatars();
+        }
 
-		this.parent.loadingMessages = false;
+        this.parent.loadingMessages = false;
 
-		this.markEmptyIfNeeded();
-	}
+        this.markEmptyIfNeeded();
+    }
 
-	async handleEffect(effect) {
-		let done = new Promise(resolve => {
-			switch (effect) {
-				case "confetti":
-					startConfetti();
-					setTimeout(() => {
-						stopConfetti();
-						resolve();
-					}, 3000);
-					break;
-			}
-		});
-		return await done;
-	}
+    async handleEffect(effect) {
+        let done = new Promise((resolve) => {
+            switch (effect) {
+                case 'confetti':
+                    startConfetti();
+                    setTimeout(() => {
+                        stopConfetti();
+                        resolve();
+                    }, 3000);
+                    break;
+            }
+        });
+        return await done;
+    }
 
-	markEmptyIfNeeded() {
-		if (!$(".messageRow").length && !$(".needSLD").length) {
-			$("#messages").addClass("empty");
-		}
-		else {
-			$("#messages").removeClass("empty");
-		}
-	}
+    markEmptyIfNeeded() {
+        if (!$('.messageRow').length && !$('.needSLD').length) {
+            $('#messages').addClass('empty');
+        } else {
+            $('#messages').removeClass('empty');
+        }
+    }
 
-	deleteMessage(id) {
-		let message = $(`.messageRow[data-id=${id}]`);
+    deleteMessage(id) {
+        let message = $(`.messageRow[data-id=${id}]`);
 
-		if (message.length) {
-			let previous = message.prev();
-			let next = message.next();
+        if (message.length) {
+            let previous = message.prev();
+            let next = message.next();
 
-			message.remove();
-			if (previous.length) {
-				this.stylizeMessage(previous);
-			}
-			if (next.length) {
-				this.stylizeMessage(next);
-			}
+            message.remove();
+            if (previous.length) {
+                this.stylizeMessage(previous);
+            }
+            if (next.length) {
+                this.stylizeMessage(next);
+            }
 
-			if (this.parent.isChannel(this.parent.conversation)) {
-				let channel = this.parent.channelForID(this.parent.conversation);
-				if (id == channel.pinned) {
-					channel.pinned = null;
-					this.setPinnedMessage();
-				}
-			}
-		}
-	}
+            if (this.parent.isChannel(this.parent.conversation)) {
+                let channel = this.parent.channelForID(
+                    this.parent.conversation
+                );
+                if (id == channel.pinned) {
+                    channel.pinned = null;
+                    this.setPinnedMessage();
+                }
+            }
+        }
+    }
 
-	updateReactions(id) {
-		let message = $(`.messageRow[data-id=${id}]`);
-		message.find(".reactions").empty();
+    updateReactions(id) {
+        let message = $(`.messageRow[data-id=${id}]`);
+        message.find('.reactions').empty();
 
-		let reactions = this.parent.messages.filter(m => {
-			return m.id == id;
-		})[0].reactions;
+        let reactions = this.parent.messages.filter((m) => {
+            return m.id == id;
+        })[0].reactions;
 
-		if (reactions) {
-			let json = JSON.parse(reactions);
-			if (Object.keys(json).length) {
-				$.each(json, (r, u) => {
-					let users = this.userString(u);
-					let reaction = $(`
+        if (reactions) {
+            let json = JSON.parse(reactions);
+            if (Object.keys(json).length) {
+                $.each(json, (r, u) => {
+                    let users = this.userString(u);
+                    let reaction = $(`
 						<div class="reaction" data-reaction="${r}" title="${users}">
 							<div>${r}</div>
 							<div class="count">${u.length}</div>
 						</div>
 					`);
 
-					if (u.includes(this.parent.domain)) {
-						reaction.addClass("self");
-					}
-
-					message.find(".reactions").append(reaction);
-				});
-			}
-		}
-	}
-
-	moveConversationToTop(conversation) {
-		let div = $(`#conversations tr[data-id=${conversation}]`);
-		let parent = div.parent();
-		div.remove();
-		parent.prepend(div);
-	}
-
-	userString(array) {
-		let output;
-
-		let users = [...array];
-		$.each(users, (k, u) => {
-			let name = this.parent.userForID(u).domain;
-			users[k] = name;
-		});
-
-		if (users.length == 1) {
-			output = users[0];
-		}
-		else {
-			let last = users.pop();
-			let others = users.join(", ");
-			output = `${others} and ${last}`;
-		}
-
-		return output;
-	}
-
-	isCharEmoji(char) {
-		if (char == "\u200d") {
-			return true;
-		}
-
-		let match = emojis.filter(emoji => {
-			return emoji.emoji == char || emoji.emoji.replace("\ufe0f", "") == char;
-		});
-
-		if (match.length) {
-			return true;
-		}
-
-		return false;
-	}
-
-	stylizeMessage(message) {
-		let messageHolder = $("#messages");
-
-		let firstMessage = $("#messages > .messageRow[data-id]").first();
-		let firstMessageID = firstMessage.data("id");
-
-		let lastMessage = $("#messages > .messageRow[data-id]").last();
-		let lastMessageID = lastMessage.data("id");
-
-		let messageID = message.data("id");
-		let messageTime = message.data("time");
-		let messageDate = new Date(messageTime * 1000).format(this.parent.dateFormat);
-		let contents = message.find(".contents");
-		let messageSender = message.data("sender");
-		let messageUser;
-
-		let previousMessage = message.prev();
-		let previousMessageTime = previousMessage.data("time");
-		let previousMessageDate = new Date(previousMessageTime * 1000).format(this.parent.dateFormat);
-		let previousMessageSender = previousMessage.data("sender");
-
-		let nextMessage = message.next();
-		let nextMessageTime = nextMessage.data("time");
-		let nextMessageDate = new Date(nextMessageTime * 1000).format(this.parent.dateFormat);
-		let nextMessageSender = nextMessage.data("sender");
-		let nextMessageUser;
-
-		let isFirst = false;
-		let isLast = false;
-
-		let isReply = false;
-
-		let isInformational = false;
-		let isAction = false;
-		let isDate = false;
-
-		let before = false;
-
-		let addUser = false;
-		let addNextUser = false;
-		let removeUser = false;
-		let removeNextUser = false;
-		
-		let prependDate = false;
-		let appendDate = false;
-
-		if (firstMessageID == messageID) {
-			isFirst = true;
-		}
-
-		if (lastMessageID == messageID) {
-			isLast = true;
-		}
-
-		if (message.hasClass("replying")) {
-			isReply = true;
-		}
-
-		if (message.hasClass("informational")) {
-			isInformational = true;
-		}
-
-		if (message.hasClass("date")) {
-			isDate = true;
-		}
-
-		if (message.hasClass("action")) {
-			isAction = true;
-		}
-
-		if (nextMessage.length) {
-			before = true;
-		}
-
-		if (isFirst || isReply) {
-			addUser = true;
-		}
-
-		if (!before) {
-			if (!isDate && previousMessage.length && messageDate !== previousMessageDate && !previousMessage.hasClass("date")) {
-				prependDate = true;
-			}
-		}
-		else {
-			if (!isDate && nextMessage.length && messageDate !== nextMessageDate && !nextMessage.hasClass("date")) {
-				appendDate = true;
-			}
-		}
-
-		if (isDate) {
-			previousMessage.addClass("last");
-			message.addClass("first last");
-
-			if (nextMessage.length) {
-				addNextUser = true;
-			}
-		}
-		else {
-			let timeDifference;
-
-			messageUser = this.parent.userForID(messageSender).domain;
-
-			if (before) {
-				message.addClass("first");
-			}
-			else {
-				message.addClass("last");	
-			}
-
-			if (isFirst || isReply) {
-				message.addClass("first");
-			}
-
-			if (isLast) {
-				message.addClass("last");
-			}
-
-			if (previousMessage.length) {
-				timeDifference = messageTime - previousMessageTime;
-
-				if (timeDifference >= 60 || previousMessageSender !== messageSender) {
-					previousMessage.addClass("last");
-					message.addClass("first");
-					addUser = true;
-				}
-				else if (!isReply) {
-					removeUser = true;
-				}
-			}
-
-			if (timeDifference < 60 && previousMessageSender == messageSender && !message.hasClass("replying")) {
-				previousMessage.removeClass("last");
-			}
-
-			if (previousMessageSender !== messageSender) {
-				previousMessage.addClass("last");
-			}
-
-			if (nextMessage.length) {
-				timeDifference = nextMessageTime - messageTime;
-
-				if (timeDifference > 60) {
-					nextMessage.addClass("first");
-					addNextUser = true;
-				}
-
-				if (nextMessage.hasClass("first")) {
-					message.addClass("last");
-				}
-			}
-
-			if (timeDifference < 60 && nextMessageSender == messageSender && !nextMessage.hasClass("replying")) {
-				removeNextUser = true;
-			}
-
-			if (addUser) {
-				if (!contents.find(".user").length) {
-					//let user = $('<div class="user" />');
-					//user.html(messageUser);
-					//contents.prepend(user);
-					//contents.prepend(messageAvatar(messageSender, messageUser));
-				}
-			}
-			if (removeUser) {
-				message.removeClass("first");
-				//message.find(".contents .user").remove();
-				//message.find(".contents .avatar").remove();
-			}
-			if (removeNextUser) {
-				message.removeClass("last");
-				nextMessage.removeClass("first");
-				//nextMessage.find(".contents .user").remove();
-				//nextMessage.find(".contents .avatar").remove();
-			}
-			if (prependDate) {
-				let infoRow = $('<div class="messageRow informational date last" />');
-				infoRow.html(messageDate);
-				infoRow.insertBefore(message);
-				this.stylizeMessage(infoRow);
-			}
-			if (appendDate) {
-				let infoRow = $('<div class="messageRow informational date last" />');
-				infoRow.html(nextMessageDate);
-				infoRow.insertAfter(message);
-				this.stylizeMessage(infoRow);
-			}
-		}
-
-		if (addNextUser) {
-			if (!nextMessage.find(".contents .user").length) {
-				//nextMessageUser = this.parent.userForID(nextMessageSender).domain;
-				//let user = $('<div class="user" />');
-				//user.html(nextMessageUser);
-				//nextMessage.addClass("first");
-				//nextMessage.find(".contents").prepend(user);
-				//nextMessage.find(".contents").prepend(messageAvatar(nextMessageSender, nextMessageUser));
-			}
-		}
-
-		let newLastMessage = $(".messageRow").last();
-		if (newLastMessage.hasClass("informational date")) {
-			newLastMessage.remove();
-		}
-
-		//this.codify(message.find(".contents .body"));
-		this.linkify(message.find(".contents .body"));
-
-		this.updateAvatars();
-	}
-
-	codify(elements) {
-		$.each(elements, (k, e) => {
-			e = $(e);
-
-			let output = e.html();
-
-			while (this.parent.regex(/\`{3}(?<code>[.\s\S]+?)\`{3}/gm, output).length) {
-				let matches = this.parent.regex(/\`{3}(?<code>[.\s\S]+?)\`{3}/gm, output);
-				
-				if (matches.length) {
-					let result = matches[0];
-					let full = result[0];
-					let code = result.groups.code;
-					let start = result.index;
-					let end = (start + full.length);
-					let replace = `<pre class="multi"><code class="hljs">${code}</code></pre>`;
-					output = this.parent.replaceRange(output, start, end, replace);
-				}
-			}
-
-			while (this.parent.regex(/\`(?<code>[.\s\S]+?)\`/gm, output).length) {
-				let matches = this.parent.regex(/\`(?<code>[.\s\S]+?)\`/gm, output);
-				
-				if (matches.length) {
-					let result = matches[0];
-					let full = result[0];
-					let code = result.groups.code;
-					let start = result.index;
-					let end = (start + full.length);
-					let replace = `<code>${code}</code>`;
-					output = this.parent.replaceRange(output, start, end, replace);
-				}
-			}
-
-			e.html(output);
-		});
-	}
-
-	linkify(elements) {
-		$.each(elements, (k, e) => {
-			e = $(e);
-
-			let output = e.html();
-			let links = anchorme.list(output).reverse();
-
-			$.each(links, (k, link) => {
-				let href = link.string;
-
-				if (link.isEmail) {
-					href = `mailto:${href}`;
-				}
-				else if (link.isURL && href.substring(0, 8) !== "https://" && href.substring(0, 7) !== "http://") {
-					href = `http://${href}`;
-				}
-
-				let replace = `<a class="inline link" href="${href}" target="_blank">${link.string}</a>`
-				output = this.parent.replaceRange(output, link.start, link.end, replace);
-			});
-
-			let mentions = this.usersInMessage(output);
-			$.each(mentions, (k, mention) => {
-				let id = mention.groups.name;
-				if (id == this.parent.domain) {
-					e.closest(".messageRow").addClass("mention");
-				}
-			});
-
-			output = this.replaceIds(output);
-			e.html(output);
-
-			this.expandLinks(e);
-		});
-	}
-
-	expandLinks(message) {
-		if (message.hasClass("expanded")) {
-			return;
-		}
-
-		message.addClass("expanded");
-
-		let links = message.find("a.inline");
-
-		if (links.length) {
-			if (!message.parent().hasClass("message")) {
-				return;
-			}
-
-			let link = links[0].href;
-			let embed = this.shouldInlineLink(link);
-			if (embed) {
-				let div;
-				switch (embed) {
-					case "image":
-						div = $(`
+                    if (u.includes(this.parent.domain)) {
+                        reaction.addClass('self');
+                    }
+
+                    message.find('.reactions').append(reaction);
+                });
+            }
+        }
+    }
+
+    moveConversationToTop(conversation) {
+        let div = $(`#conversations tr[data-id=${conversation}]`);
+        let parent = div.parent();
+        div.remove();
+        parent.prepend(div);
+    }
+
+    userString(array) {
+        let output;
+
+        let users = [...array];
+        $.each(users, (k, u) => {
+            let name = this.parent.userForID(u).domain;
+            users[k] = name;
+        });
+
+        if (users.length == 1) {
+            output = users[0];
+        } else {
+            let last = users.pop();
+            let others = users.join(', ');
+            output = `${others} and ${last}`;
+        }
+
+        return output;
+    }
+
+    isCharEmoji(char) {
+        if (char == '\u200d') {
+            return true;
+        }
+
+        let match = emojis.filter((emoji) => {
+            return (
+                emoji.emoji == char || emoji.emoji.replace('\ufe0f', '') == char
+            );
+        });
+
+        if (match.length) {
+            return true;
+        }
+
+        return false;
+    }
+
+    stylizeMessage(message) {
+        let messageHolder = $('#messages');
+
+        let firstMessage = $('#messages > .messageRow[data-id]').first();
+        let firstMessageID = firstMessage.data('id');
+
+        let lastMessage = $('#messages > .messageRow[data-id]').last();
+        let lastMessageID = lastMessage.data('id');
+
+        let messageID = message.data('id');
+        let messageTime = message.data('time');
+        let messageDate = new Date(messageTime * 1000).format(
+            this.parent.dateFormat
+        );
+        let contents = message.find('.contents');
+        let messageSender = message.data('sender');
+        let messageUser;
+
+        let previousMessage = message.prev();
+        let previousMessageTime = previousMessage.data('time');
+        let previousMessageDate = new Date(previousMessageTime * 1000).format(
+            this.parent.dateFormat
+        );
+        let previousMessageSender = previousMessage.data('sender');
+
+        let nextMessage = message.next();
+        let nextMessageTime = nextMessage.data('time');
+        let nextMessageDate = new Date(nextMessageTime * 1000).format(
+            this.parent.dateFormat
+        );
+        let nextMessageSender = nextMessage.data('sender');
+        let nextMessageUser;
+
+        let isFirst = false;
+        let isLast = false;
+
+        let isReply = false;
+
+        let isInformational = false;
+        let isAction = false;
+        let isDate = false;
+
+        let before = false;
+
+        let addUser = false;
+        let addNextUser = false;
+        let removeUser = false;
+        let removeNextUser = false;
+
+        let prependDate = false;
+        let appendDate = false;
+
+        if (firstMessageID == messageID) {
+            isFirst = true;
+        }
+
+        if (lastMessageID == messageID) {
+            isLast = true;
+        }
+
+        if (message.hasClass('replying')) {
+            isReply = true;
+        }
+
+        if (message.hasClass('informational')) {
+            isInformational = true;
+        }
+
+        if (message.hasClass('date')) {
+            isDate = true;
+        }
+
+        if (message.hasClass('action')) {
+            isAction = true;
+        }
+
+        if (nextMessage.length) {
+            before = true;
+        }
+
+        if (isFirst || isReply) {
+            addUser = true;
+        }
+
+        if (!before) {
+            if (
+                !isDate &&
+                previousMessage.length &&
+                messageDate !== previousMessageDate &&
+                !previousMessage.hasClass('date')
+            ) {
+                prependDate = true;
+            }
+        } else {
+            if (
+                !isDate &&
+                nextMessage.length &&
+                messageDate !== nextMessageDate &&
+                !nextMessage.hasClass('date')
+            ) {
+                appendDate = true;
+            }
+        }
+
+        if (isDate) {
+            previousMessage.addClass('last');
+            message.addClass('first last');
+
+            if (nextMessage.length) {
+                addNextUser = true;
+            }
+        } else {
+            let timeDifference;
+
+            messageUser = this.parent.userForID(messageSender).domain;
+
+            if (before) {
+                message.addClass('first');
+            } else {
+                message.addClass('last');
+            }
+
+            if (isFirst || isReply) {
+                message.addClass('first');
+            }
+
+            if (isLast) {
+                message.addClass('last');
+            }
+
+            if (previousMessage.length) {
+                timeDifference = messageTime - previousMessageTime;
+
+                if (
+                    timeDifference >= 60 ||
+                    previousMessageSender !== messageSender
+                ) {
+                    previousMessage.addClass('last');
+                    message.addClass('first');
+                    addUser = true;
+                } else if (!isReply) {
+                    removeUser = true;
+                }
+            }
+
+            if (
+                timeDifference < 60 &&
+                previousMessageSender == messageSender &&
+                !message.hasClass('replying')
+            ) {
+                previousMessage.removeClass('last');
+            }
+
+            if (previousMessageSender !== messageSender) {
+                previousMessage.addClass('last');
+            }
+
+            if (nextMessage.length) {
+                timeDifference = nextMessageTime - messageTime;
+
+                if (timeDifference > 60) {
+                    nextMessage.addClass('first');
+                    addNextUser = true;
+                }
+
+                if (nextMessage.hasClass('first')) {
+                    message.addClass('last');
+                }
+            }
+
+            if (
+                timeDifference < 60 &&
+                nextMessageSender == messageSender &&
+                !nextMessage.hasClass('replying')
+            ) {
+                removeNextUser = true;
+            }
+
+            if (addUser) {
+                if (!contents.find('.user').length) {
+                    //let user = $('<div class="user" />');
+                    //user.html(messageUser);
+                    //contents.prepend(user);
+                    //contents.prepend(messageAvatar(messageSender, messageUser));
+                }
+            }
+            if (removeUser) {
+                message.removeClass('first');
+                //message.find(".contents .user").remove();
+                //message.find(".contents .avatar").remove();
+            }
+            if (removeNextUser) {
+                message.removeClass('last');
+                nextMessage.removeClass('first');
+                //nextMessage.find(".contents .user").remove();
+                //nextMessage.find(".contents .avatar").remove();
+            }
+            if (prependDate) {
+                let infoRow = $(
+                    '<div class="messageRow informational date last" />'
+                );
+                infoRow.html(messageDate);
+                infoRow.insertBefore(message);
+                this.stylizeMessage(infoRow);
+            }
+            if (appendDate) {
+                let infoRow = $(
+                    '<div class="messageRow informational date last" />'
+                );
+                infoRow.html(nextMessageDate);
+                infoRow.insertAfter(message);
+                this.stylizeMessage(infoRow);
+            }
+        }
+
+        if (addNextUser) {
+            if (!nextMessage.find('.contents .user').length) {
+                //nextMessageUser = this.parent.userForID(nextMessageSender).domain;
+                //let user = $('<div class="user" />');
+                //user.html(nextMessageUser);
+                //nextMessage.addClass("first");
+                //nextMessage.find(".contents").prepend(user);
+                //nextMessage.find(".contents").prepend(messageAvatar(nextMessageSender, nextMessageUser));
+            }
+        }
+
+        let newLastMessage = $('.messageRow').last();
+        if (newLastMessage.hasClass('informational date')) {
+            newLastMessage.remove();
+        }
+
+        //this.codify(message.find(".contents .body"));
+        this.linkify(message.find('.contents .body'));
+
+        this.updateAvatars();
+    }
+
+    codify(elements) {
+        $.each(elements, (k, e) => {
+            e = $(e);
+
+            let output = e.html();
+
+            while (
+                this.parent.regex(/\`{3}(?<code>[.\s\S]+?)\`{3}/gm, output)
+                    .length
+            ) {
+                let matches = this.parent.regex(
+                    /\`{3}(?<code>[.\s\S]+?)\`{3}/gm,
+                    output
+                );
+
+                if (matches.length) {
+                    let result = matches[0];
+                    let full = result[0];
+                    let code = result.groups.code;
+                    let start = result.index;
+                    let end = start + full.length;
+                    let replace = `<pre class="multi"><code class="hljs">${code}</code></pre>`;
+                    output = this.parent.replaceRange(
+                        output,
+                        start,
+                        end,
+                        replace
+                    );
+                }
+            }
+
+            while (
+                this.parent.regex(/\`(?<code>[.\s\S]+?)\`/gm, output).length
+            ) {
+                let matches = this.parent.regex(
+                    /\`(?<code>[.\s\S]+?)\`/gm,
+                    output
+                );
+
+                if (matches.length) {
+                    let result = matches[0];
+                    let full = result[0];
+                    let code = result.groups.code;
+                    let start = result.index;
+                    let end = start + full.length;
+                    let replace = `<code>${code}</code>`;
+                    output = this.parent.replaceRange(
+                        output,
+                        start,
+                        end,
+                        replace
+                    );
+                }
+            }
+
+            e.html(output);
+        });
+    }
+
+    linkify(elements) {
+        $.each(elements, (k, e) => {
+            e = $(e);
+
+            let output = e.html();
+            let links = anchorme.list(output).reverse();
+
+            $.each(links, (k, link) => {
+                let href = link.string;
+
+                if (link.isEmail) {
+                    href = `mailto:${href}`;
+                } else if (
+                    link.isURL &&
+                    href.substring(0, 8) !== 'https://' &&
+                    href.substring(0, 7) !== 'http://'
+                ) {
+                    href = `http://${href}`;
+                }
+
+                let replace = `<a class="inline link" href="${href}" target="_blank">${link.string}</a>`;
+                output = this.parent.replaceRange(
+                    output,
+                    link.start,
+                    link.end,
+                    replace
+                );
+            });
+
+            let mentions = this.usersInMessage(output);
+            $.each(mentions, (k, mention) => {
+                let id = mention.groups.name;
+                if (id == this.parent.domain) {
+                    e.closest('.messageRow').addClass('mention');
+                }
+            });
+
+            output = this.replaceIds(output);
+            e.html(output);
+
+            this.expandLinks(e);
+        });
+    }
+
+    expandLinks(message) {
+        if (message.hasClass('expanded')) {
+            return;
+        }
+
+        message.addClass('expanded');
+
+        let links = message.find('a.inline');
+
+        if (links.length) {
+            if (!message.parent().hasClass('message')) {
+                return;
+            }
+
+            let link = links[0].href;
+            let embed = this.shouldInlineLink(link);
+            if (embed) {
+                let div;
+                switch (embed) {
+                    case 'image':
+                        div = $(`
 							<a href="${link}" class="previewImage" target="_blank">
 								<div class="preview">
 									<div class="media">
@@ -1602,10 +1747,10 @@ export class ui {
 								</div>
 							</a>
 						`);
-						break;
+                        break;
 
-					case "video":
-						div = $(`
+                    case 'video':
+                        div = $(`
 							<div class="preview">
 								<div class="media">
 									<video controls>
@@ -1614,40 +1759,46 @@ export class ui {
 								</div>
 							</div>
 						`);
-						break;
-				}
+                        break;
+                }
 
-				if (div) {
-					message.closest(".messageRow").find(".linkHolder").append(div);
-					this.fixScroll();
-				}
-			}
-			else {
-				let data = {
-					action: "getMetaTags",
-					url: link
-				}
-				if (link.substring(0, 7) == "mailto:") {
-					return;
-				}
-				this.parent.api(data).then(r => {
-					let div = $(`
+                if (div) {
+                    message
+                        .closest('.messageRow')
+                        .find('.linkHolder')
+                        .append(div);
+                    this.fixScroll();
+                }
+            } else {
+                let data = {
+                    action: 'getMetaTags',
+                    url: link,
+                };
+                if (link.substring(0, 7) == 'mailto:') {
+                    return;
+                }
+                this.parent.api(data).then((r) => {
+                    let div = $(`
 						<a href="${link}" class="previewLink" target="_blank">
 							<div class="preview"></div>
 							<div class="info"></div>
 						</a>
 					`);
 
-					if (r.tags) {
-						let t = r.tags;
-						if (t.title) {
-							div.find(".info").append(`<div class="title">${t.title}</div>`);
+                    if (r.tags) {
+                        let t = r.tags;
+                        if (t.title) {
+                            div.find('.info').append(
+                                `<div class="title">${t.title}</div>`
+                            );
 
-							if (t.description) {
-								div.find(".info").append(`<div class="subtitle">${t.description}</div>`);
-							}
+                            if (t.description) {
+                                div.find('.info').append(
+                                    `<div class="subtitle">${t.description}</div>`
+                                );
+                            }
 
-							/*
+                            /*
 							if (t.video) {
 								div.find(".preview").prepend(`
 									<div class="media">
@@ -1657,1503 +1808,1635 @@ export class ui {
 							}
 							else
 							*/
-							if (t.image) {
-								div.find(".preview").prepend(`
+                            if (t.image) {
+                                div.find('.preview').prepend(`
 									<div class="media">
 										<img src="https://${window.location.host}${t.image}">
 									</div>
 								`);
-							}
-
-							message.closest(".messageRow").find(".linkHolder").append(div);
-							this.fixScroll();
-						}
-					}
-				});
-			}
-		}
-	}
-
-	shouldInlineLink(link) {
-		try {
-			let url = new URL(link);
-
-			let match;
-			switch (url.host) {
-				case "hns.chat":
-				case "hnschat":
-				case window.location.host:
-					match = url.pathname.match(/^(\/uploads\/.{32}|\/avatar\/.{16})$/);
-					if (match) {
-						return "image";
-					}
-					break;
-
-				case "i.arxius.io":
-					match = url.pathname.match(/^\/.{8}\.(jpeg|jpg|png|gif)$/);
-					if (match) {
-						return "image";
-					}
-					break;
-
-				case "v.arxius.io":
-					match = url.pathname.match(/^\/.{8}$/);
-					if (match) {
-						return "video";
-					}
-					break;
-
-				case "i.imgur.com":
-					match = url.pathname.match(/^\/.{7}\.(jpeg|jpg|png|gif)$/);
-					if (match) {
-						return "image";
-					}
-					break;
-
-				case "i.redd.it":
-					match = url.pathname.match(/^\/.{13}\.(jpeg|jpg|png|gif)$/);
-					if (match) {
-						return "image";
-					}
-					break;
-			}
-		}
-		catch {}
-
-		return false;
-	}
-
-	usersInMessage(message) {
-		let matches = this.parent.regex(/\@(?<id>[a-zA-Z0-9]{16}(?:\b|$))/gm, message);
-		return matches;
-	}
-
-	channelsInMessage(message) {
-		let matches = this.parent.regex(/\@(?<id>[a-zA-Z0-9]{8}(?:\b|$))/gm, message);
-		return matches;
-	}
-
-	replaceIds(message, link=true) {
-		let output = message;
-
-		while (this.channelsInMessage(output).length) {
-			let channels = this.channelsInMessage(output);
-			let result = channels[0];
-
-			let id = result.groups.id;
-			let start = result.index;
-			let end = (start + id.length + 1);
-			
-			let replace;
-			let match = this.parent.channelForID(id);
-			if (match) {
-				let channel = match.name;
-				replace = `<div class="inline channel" data-id="${id}">#${this.toUnicode(channel)}</div>`;
-			}
-			else {
-				replace = `@\x00${id}`;
-			}
-			output = this.parent.replaceRange(output, start, end, replace);
-		}
-
-		while (this.usersInMessage(output).length) {
-			let users = this.usersInMessage(output);
-			let result = users[0];
-
-			let id = result.groups.id;
-			let start = result.index;
-			let end = (start + id.length + 1);
-
-			let replace;
-			let match = this.parent.userForID(id);
-			if (match) {
-				let domain = match.domain;
-				replace = `<div class="inline nick" data-id="${id}">@${this.toUnicode(domain)}/</div>`;
-			}
-			else {
-				replace = `@\x00${id}`;
-			}
-			output = this.parent.replaceRange(output, start, end, replace);
-		}
-
-		return output;
-	}
-
-	preventTabIfNeeded(e) {
-		let target = $(e.target);
-
-		if (this.parent.isKey(e, 9)) {
-			if (!target.hasClass("tab")) {
-				e.preventDefault();
-			}
-		}
-	}
-
-	focusInputIfNeeded(e) {
-		if (!$("input").is(":focus") && !$("#message").is(":focus") && !$("#blackout").is(":visible")) {
-			if ((this.parent.keyName(e).length == 1 || this.parent.isKey(e, 9)) && !((e.ctrlKey || e.metaKey))) {
-				if (this.parent.isKey(e, 9)) {
-					e.preventDefault();
-				}
-				$("#message").focus();
-			}
-		}
-	}
-
-	removePopoverIfNeeded() {
-		if ($("#blackout").is(":visible")) {
-			this.close();
-			return true;
-		}
-		return false;
-	}
-
-	removeReplyingIfNeeded() {
-		if (!$(".popover.shown").length && $("#replying.shown").length) {
-			$(".action[data-action=removeReply]").click();
-			return true;
-		}
-		return false;
-	}
-
-	undoProfileIfNeeded() {
-		if ($(".contextMenu[data-name=userContext].me.editing.shown").length) {
-			this.undoProfile();
-			return true;
-		}
-		return false;
-	}
-
-	updateReplying() {
-		if (this.parent.replying) {
-			let name = this.toUnicode(this.parent.userForID(this.parent.replying.sender).domain);
-			$("#replying .message .name").html(name);
-			$("#replying").addClass("shown");
-
-			$("#holder").addClass("replying");
-			$(".messageRow").removeClass("selected");
-			$(".messageRow").removeClass("selecting");
-			$(`.messageRow[data-id=${this.parent.replying.message}]`).addClass("selected");
-		}
-		else {
-			$("#replying").removeClass("shown");
-			$("#replying .message .name").html('');
-			$("#holder").removeClass("replying");
-			$(`.messageRow`).removeClass("selected");
-		}
-	}
-
-	async popover(action) {
-		$(".popover.shown").removeClass("shown");
-
-		let popover = $(`.popover[data-name=${action}]`);
-
-		let output = new Promise(resolve => {
-			switch (action) {
-				case "syncSession":
-					resolve();
-					break;
-
-				case "pay":
-					popover.find("input[name=hns]").inputmask({mask: "9{+}[.9{1,6}] HNS", greedy: false, placeholder: "0"});
-					popover.find(".response").html("");
-
-					resolve();
-
-					let to = getOtherUser(conversation).domain;
-					let toID = getOtherUserID(conversation);
-
-					let data = {
-						action: "getAddress",
-						domain: toID
-					}
-					api(data).then(r => {
-						popover.find(".loading").removeClass("shown");
-
-						if (r.success) {
-							popover.find(".subtitle").html(to+"/ is able to accept payments!");
-							popover.find("input[name=address]").val(r.address);
-							popover.find(".content").addClass("shown");
-							popover.find("input[name=hns]").focus();
-						}
-						else {
-							popover.find(".response").addClass("error");
-							popover.find(".response").html(r.message);
-						}
-					});
-					break;
-
-				case "settings":
-					popover.find("input[name=avatar]").parent().addClass("hidden");
-					popover.find("input[name=address]").parent().addClass("hidden");
-
-					let user = this.parent.userForID(this.parent.domain);
-					let tld = user.tld;
-
-					if (["hnschat", "theshake"].includes(tld)) {
-						popover.find("input[name=address]").parent().removeClass("hidden");
-						popover.find("input[name=avatar]").parent().removeClass("hidden");
-						popover.find("input[name=avatar]").val(user.avatar);
-
-						let data = {
-							action: "getAddress",
-							domain: this.parent.domain
-						}
-
-						this.parent.api(data).then(r => {
-							if (r.address) {
-								popover.find("input[name=address]").val(r.address);
-							}
-							resolve();
-						});
-					}
-					else {
-						resolve();
-					}
-					break;
-
-				case "completions":
-				case "emojis":
-					let bottom = $(".inputHolder").outerHeight() + 10;
-					popover.css("bottom", bottom+"px");
-					resolve();
-					break;
-
-				default:
-					resolve();
-					break;
-			}
-		});
-
-		output.then(() => {
-			if (popover.length) {
-				$("#blackout").addClass("shown");
-				$("#messageHolder").addClass("noScroll");
-				popover.addClass("shown");
-
-				if (action == "newConversation" && popover.find("input[name=domain]").val()) {
-					popover.find("input[name=message]").focus();
-				}
-				else {
-					let first = popover.find("input:visible:first");
-					if (first.attr("type") !== "color") {
-						if (this.isDesktop()) {
-							if (!["syncSession"].includes(action)) {
-								first.focus();
-							}
-						}
-						else {
-							if (!["syncSession", "react"].includes(action)) {
-								first.focus();
-							}
-						}
-					}
-				}
-
-				if (action === "emojis") {
-					$(".popover[data-name=emojis] .body .grid[data-type=emojis]").scrollTop(0);
-				}
-			}
-		});
-	}
-
-	close(old=false) {
-		$("#blackout").removeClass("shown");
-		$("#completions").removeClass("shown");
-		$(".popover.shown").find("input:not([readonly])").val('');
-		$(".popover.shown").find(".response").html('');
-		$(".popover.shown").find(".content").removeClass("shown");
-		$(".popover.shown").find(".loading").addClass("shown");
-		$(".popover.shown").find(".button").removeClass("disabled");
-		$(".popover[data-name=react]").find(".grid[data-type=gifs]").scrollTop(0);
-		$(".popover.shown").removeClass("shown");
-		$("#messageHolder").removeClass("noScroll");
-		$(".popover[data-name=react] .grid[data-type=emojis] .section").removeClass("hidden");
-		$(".popover[data-name=react] .grid[data-type=emojis] .section[data-name=Search]").addClass("hidden");
-		$("#holder").removeClass("reacting");
-		$(".messageRow .hover.visible").removeClass("visible");
-		$("#users .user.selected").removeClass("selected");
-		$(".popover[data-name=react] .section[data-type=gifs] .column").empty();
-
-		$(".messageRow").removeClass("selecting");
-		if (!$("#holder").hasClass("reacting") && !$("#holder").hasClass("replying")) {
-			$(".messageRow").removeClass("selected");
-		}
-
-		this.updateReplying();
-		this.undoProfile();
-		this.shouldShowGifs();
-	}
-
-	messagesLoading(bool) {
-		if (bool) {
-			$("#messageHolder #messages").addClass("hidden");
-			$("#messageHolder .loading").addClass("shown");
-		}
-		else {
-			$("#messageHolder .loading").removeClass("shown");
-			$("#messageHolder #messages").removeClass("hidden");
-		}
-	}
-
-	updateAvatars() {
-		$.each($(".favicon:not(.loaded)"), (k, e) => {
-			let favicon = $(e);
-			favicon.addClass("loaded");
-			let d = favicon.data("domain");
-			let id = favicon.data("id");
-			let user = this.parent.userForID(id);
-
-			if (user.id) {
-				if (Object.keys(this.parent.avatars).includes(id)) {
-					if (this.parent.avatars[id]) {
-						let original = $("#avatars .favicon[data-id="+id+"]");
-						if (original.length) {
-							let clone = original[0].cloneNode(true);
-							let parent = favicon.parent();
-							favicon.remove();
-							parent.append(clone);
-							//parent.find(".fallback").html('');
-							this.updateOtherAvatars(id);
-						}
-					}
-				}
-				else {
-					this.parent.avatars[id] = false;
-					let link = user.avatar;
-					if (link) {
-						link = `https://${window.location.host}/avatar/${user.id}`;
-						let img = $('<img class="loading" />');
-						img.attr("src", link).on("load", i => {
-							let im = $(i.target);
-							favicon.css("background-image", "url("+link+")");
-							//favicon.parent().find(".fallback").html('');
-							im.remove();
-							this.parent.avatars[id] = link;
-							let clone = favicon[0].cloneNode(true);
-							$("#avatars").append(clone);
-							this.updateOtherAvatars(user.id);
-						}).on("error", r => {
-							$(r.target).remove();
-							//this.parent.avatars[id] = false;
-						});  
-						$("html").append(img);
-					}
-					else {
-						this.parent.avatars[id] = false;
-					}
-				}
-			}
-		});
-	}
-
-	updateOtherAvatars(id) {
-		if (this.parent.avatars[id]) {
-			let avatars = [
-				$(`#conversations .section.pms .avatar .favicon[data-id=${id}].loaded`),
-				$(`.messageHeader .avatar .favicon[data-id=${id}].loaded`),
-				$(`#messages .messageRow .avatar .favicon[data-id=${id}].loaded`),
-				$(`#users .user .avatar .favicon[data-id=${id}].loaded`),
-				$(`.contextMenu[data-name=userContext] .avatar .favicon[data-id=${id}].loaded`),
-				$(`.header .avatar .favicon[data-id=${id}].loaded`),
-				$(`#videoInfo .users .avatar .favicon[data-id=${id}].loaded`)
-			];
-
-			$.each(avatars, (k, avatar) => {
-				if (avatar.length) {
-					$.each(avatar, (k, a) => {
-						a = $(a);
-						if (a.css("background-image") === "none" || !a.css("background-image")) {
-							let original = $("#avatars .favicon[data-id="+id+"]");
-							if (original.length) {
-								let clone = original[0].cloneNode(true);
-								let parent = a.parent();
-								a.remove();
-								parent.append(clone);
-								//parent.find(".fallback").html('');
-							}
-						}
-					});
-				}
-			});
-		}
-	}
-
-	setContextMenuPosition(menu, e) {
-		if (!this.isDesktop()) {
-			return;
-		}
-
-		let hx = window.innerWidth / 2;
-		let hy = window.innerHeight / 2;
-		let x = e.clientX;
-		let y = e.clientY;
-
-		if (x >= hx) {
-			x = e.clientX - menu.outerWidth();
-		}
-		if (y >= hy) {
-			y = e.clientY - menu.outerHeight();
-		}
-
-		menu.css({ top: y, left: x });
-	}
-
-	setCaretPosition(ctrl, pos) {
-		if (ctrl.setSelectionRange) {
-			ctrl.focus();
-			ctrl.setSelectionRange(pos, pos);
-		} 
-		else if (ctrl.createTextRange) {
-			let range = ctrl.createTextRange();
-			range.collapse(true);
-			range.moveEnd('character', pos);
-			range.moveStart('character', pos);
-			range.select();
-		}
-		else {
-			var range = document.createRange();
-			var selection = window.getSelection();
-			range.setStart(ctrl[0].childNodes[0], pos);
-			range.collapse(true);
-			selection.removeAllRanges();
-			selection.addRange(range);
-		}
-	}
-
-	categoryForEmoji(emoji) {
-		let cat = false;
-		$.each(Object.keys(this.emojiCategories), (k, category) => {
-			let data = this.emojiCategories[category];
-			if (data.includes(emoji.category)) {
-				cat = category;
-				return false;
-			}
-		});
-
-		if (cat) {
-			return cat;
-		}
-
-		return false;
-	}
-
-	setupReactView(e, sender) {
-		let target = $(e.target);
-		let action = target.data("action");
-
-		let menu = $(".popover[data-name=react]");
-		if (!sender) {
-			sender = "";
-		}
-		this.setData(menu, "sender", sender);
-
-		menu.find(".tab[data-name=categories]").addClass("hidden");
-		menu.find(".tab[data-name=gifs]").addClass("hidden");
-
-		if (sender) {
-			let row = $(`.messageRow[data-id=${sender}]`);
-
-			if (!row.length) {
-				let id = target.closest(".body").find("span.message").data("id");
-				row = $("#messages").find(`.messageRow[data-id=${id}]`);
-			}
-
-			$("#holder").addClass("reacting");
-			$(`.messageRow`).removeClass("selected");
-			$(".messageRow").removeClass("selecting");
-			row.addClass("selected");
-
-			let hover = row.find(".hover");
-			hover.addClass("visible");
-			menu.addClass("react");
-			this.setContextMenuPosition(menu, e);
-		}
-		else {
-			menu.find(".tab[data-name=gifs]").removeClass("hidden");
-			menu.removeClass("react");
-			menu.css({ top: "auto" });
-		}
-
-		if (!menu.hasClass("loaded")) {
-			let data = {
-				action: "getGifCategories"
-			}
-			this.parent.api(data).then(r => {
-				if (r.success) {
-					$.each(r.categories, (k, c) => {
-						let category = $(`
+                            }
+
+                            message
+                                .closest('.messageRow')
+                                .find('.linkHolder')
+                                .append(div);
+                            this.fixScroll();
+                        }
+                    }
+                });
+            }
+        }
+    }
+
+    shouldInlineLink(link) {
+        try {
+            let url = new URL(link);
+
+            let match;
+            switch (url.host) {
+                case 'hns.chat':
+                case 'hnschat':
+                case window.location.host:
+                    match = url.pathname.match(
+                        /^(\/uploads\/.{32}|\/avatar\/.{16})$/
+                    );
+                    if (match) {
+                        return 'image';
+                    }
+                    break;
+
+                case 'i.arxius.io':
+                    match = url.pathname.match(/^\/.{8}\.(jpeg|jpg|png|gif)$/);
+                    if (match) {
+                        return 'image';
+                    }
+                    break;
+
+                case 'v.arxius.io':
+                    match = url.pathname.match(/^\/.{8}$/);
+                    if (match) {
+                        return 'video';
+                    }
+                    break;
+
+                case 'i.imgur.com':
+                    match = url.pathname.match(/^\/.{7}\.(jpeg|jpg|png|gif)$/);
+                    if (match) {
+                        return 'image';
+                    }
+                    break;
+
+                case 'i.redd.it':
+                    match = url.pathname.match(/^\/.{13}\.(jpeg|jpg|png|gif)$/);
+                    if (match) {
+                        return 'image';
+                    }
+                    break;
+            }
+        } catch {}
+
+        return false;
+    }
+
+    usersInMessage(message) {
+        let matches = this.parent.regex(
+            /\@(?<id>[a-zA-Z0-9]{16}(?:\b|$))/gm,
+            message
+        );
+        return matches;
+    }
+
+    channelsInMessage(message) {
+        let matches = this.parent.regex(
+            /\@(?<id>[a-zA-Z0-9]{8}(?:\b|$))/gm,
+            message
+        );
+        return matches;
+    }
+
+    replaceIds(message, link = true) {
+        let output = message;
+
+        while (this.channelsInMessage(output).length) {
+            let channels = this.channelsInMessage(output);
+            let result = channels[0];
+
+            let id = result.groups.id;
+            let start = result.index;
+            let end = start + id.length + 1;
+
+            let replace;
+            let match = this.parent.channelForID(id);
+            if (match) {
+                let channel = match.name;
+                replace = `<div class="inline channel" data-id="${id}">#${this.toUnicode(
+                    channel
+                )}</div>`;
+            } else {
+                replace = `@\x00${id}`;
+            }
+            output = this.parent.replaceRange(output, start, end, replace);
+        }
+
+        while (this.usersInMessage(output).length) {
+            let users = this.usersInMessage(output);
+            let result = users[0];
+
+            let id = result.groups.id;
+            let start = result.index;
+            let end = start + id.length + 1;
+
+            let replace;
+            let match = this.parent.userForID(id);
+            if (match) {
+                let domain = match.domain;
+                replace = `<div class="inline nick" data-id="${id}">@${this.toUnicode(
+                    domain
+                )}/</div>`;
+            } else {
+                replace = `@\x00${id}`;
+            }
+            output = this.parent.replaceRange(output, start, end, replace);
+        }
+
+        return output;
+    }
+
+    preventTabIfNeeded(e) {
+        let target = $(e.target);
+
+        if (this.parent.isKey(e, 9)) {
+            if (!target.hasClass('tab')) {
+                e.preventDefault();
+            }
+        }
+    }
+
+    focusInputIfNeeded(e) {
+        if (
+            !$('input').is(':focus') &&
+            !$('#message').is(':focus') &&
+            !$('#blackout').is(':visible')
+        ) {
+            if (
+                (this.parent.keyName(e).length == 1 ||
+                    this.parent.isKey(e, 9)) &&
+                !(e.ctrlKey || e.metaKey)
+            ) {
+                if (this.parent.isKey(e, 9)) {
+                    e.preventDefault();
+                }
+                $('#message').focus();
+            }
+        }
+    }
+
+    removePopoverIfNeeded() {
+        if ($('#blackout').is(':visible')) {
+            this.close();
+            return true;
+        }
+        return false;
+    }
+
+    removeReplyingIfNeeded() {
+        if (!$('.popover.shown').length && $('#replying.shown').length) {
+            $('.action[data-action=removeReply]').click();
+            return true;
+        }
+        return false;
+    }
+
+    undoProfileIfNeeded() {
+        if ($('.contextMenu[data-name=userContext].me.editing.shown').length) {
+            this.undoProfile();
+            return true;
+        }
+        return false;
+    }
+
+    updateReplying() {
+        if (this.parent.replying) {
+            let name = this.toUnicode(
+                this.parent.userForID(this.parent.replying.sender).domain
+            );
+            $('#replying .message .name').html(name);
+            $('#replying').addClass('shown');
+
+            $('#holder').addClass('replying');
+            $('.messageRow').removeClass('selected');
+            $('.messageRow').removeClass('selecting');
+            $(`.messageRow[data-id=${this.parent.replying.message}]`).addClass(
+                'selected'
+            );
+        } else {
+            $('#replying').removeClass('shown');
+            $('#replying .message .name').html('');
+            $('#holder').removeClass('replying');
+            $(`.messageRow`).removeClass('selected');
+        }
+    }
+
+    async popover(action) {
+        $('.popover.shown').removeClass('shown');
+
+        let popover = $(`.popover[data-name=${action}]`);
+
+        let output = new Promise((resolve) => {
+            switch (action) {
+                case 'syncSession':
+                    resolve();
+                    break;
+
+                case 'pay':
+                    popover.find('input[name=hns]').inputmask({
+                        mask: '9{+}[.9{1,6}] HNS',
+                        greedy: false,
+                        placeholder: '0',
+                    });
+                    popover.find('.response').html('');
+
+                    resolve();
+
+                    let to = getOtherUser(conversation).domain;
+                    let toID = getOtherUserID(conversation);
+
+                    let data = {
+                        action: 'getAddress',
+                        domain: toID,
+                    };
+                    api(data).then((r) => {
+                        popover.find('.loading').removeClass('shown');
+
+                        if (r.success) {
+                            popover
+                                .find('.subtitle')
+                                .html(to + '/ is able to accept payments!');
+                            popover.find('input[name=address]').val(r.address);
+                            popover.find('.content').addClass('shown');
+                            popover.find('input[name=hns]').focus();
+                        } else {
+                            popover.find('.response').addClass('error');
+                            popover.find('.response').html(r.message);
+                        }
+                    });
+                    break;
+
+                case 'settings':
+                    popover
+                        .find('input[name=avatar]')
+                        .parent()
+                        .addClass('hidden');
+                    popover
+                        .find('input[name=address]')
+                        .parent()
+                        .addClass('hidden');
+
+                    let user = this.parent.userForID(this.parent.domain);
+                    let tld = user.tld;
+
+                    if (['hnschat', 'theshake'].includes(tld)) {
+                        popover
+                            .find('input[name=address]')
+                            .parent()
+                            .removeClass('hidden');
+                        popover
+                            .find('input[name=avatar]')
+                            .parent()
+                            .removeClass('hidden');
+                        popover.find('input[name=avatar]').val(user.avatar);
+
+                        let data = {
+                            action: 'getAddress',
+                            domain: this.parent.domain,
+                        };
+
+                        this.parent.api(data).then((r) => {
+                            if (r.address) {
+                                popover
+                                    .find('input[name=address]')
+                                    .val(r.address);
+                            }
+                            resolve();
+                        });
+                    } else {
+                        resolve();
+                    }
+                    break;
+
+                case 'completions':
+                case 'emojis':
+                    let bottom = $('.inputHolder').outerHeight() + 10;
+                    popover.css('bottom', bottom + 'px');
+                    resolve();
+                    break;
+
+                default:
+                    resolve();
+                    break;
+            }
+        });
+
+        output.then(() => {
+            if (popover.length) {
+                $('#blackout').addClass('shown');
+                $('#messageHolder').addClass('noScroll');
+                popover.addClass('shown');
+
+                if (
+                    action == 'newConversation' &&
+                    popover.find('input[name=domain]').val()
+                ) {
+                    popover.find('input[name=message]').focus();
+                } else {
+                    let first = popover.find('input:visible:first');
+                    if (first.attr('type') !== 'color') {
+                        if (this.isDesktop()) {
+                            if (!['syncSession'].includes(action)) {
+                                first.focus();
+                            }
+                        } else {
+                            if (!['syncSession', 'react'].includes(action)) {
+                                first.focus();
+                            }
+                        }
+                    }
+                }
+
+                if (action === 'emojis') {
+                    $(
+                        '.popover[data-name=emojis] .body .grid[data-type=emojis]'
+                    ).scrollTop(0);
+                }
+            }
+        });
+    }
+
+    close(old = false) {
+        $('#blackout').removeClass('shown');
+        $('#completions').removeClass('shown');
+        $('.popover.shown').find('input:not([readonly])').val('');
+        $('.popover.shown').find('.response').html('');
+        $('.popover.shown').find('.content').removeClass('shown');
+        $('.popover.shown').find('.loading').addClass('shown');
+        $('.popover.shown').find('.button').removeClass('disabled');
+        $('.popover[data-name=react]')
+            .find('.grid[data-type=gifs]')
+            .scrollTop(0);
+        $('.popover.shown').removeClass('shown');
+        $('#messageHolder').removeClass('noScroll');
+        $(
+            '.popover[data-name=react] .grid[data-type=emojis] .section'
+        ).removeClass('hidden');
+        $(
+            '.popover[data-name=react] .grid[data-type=emojis] .section[data-name=Search]'
+        ).addClass('hidden');
+        $('#holder').removeClass('reacting');
+        $('.messageRow .hover.visible').removeClass('visible');
+        $('#users .user.selected').removeClass('selected');
+        $('.popover[data-name=react] .section[data-type=gifs] .column').empty();
+
+        $('.messageRow').removeClass('selecting');
+        if (
+            !$('#holder').hasClass('reacting') &&
+            !$('#holder').hasClass('replying')
+        ) {
+            $('.messageRow').removeClass('selected');
+        }
+
+        this.updateReplying();
+        this.undoProfile();
+        this.shouldShowGifs();
+    }
+
+    messagesLoading(bool) {
+        if (bool) {
+            $('#messageHolder #messages').addClass('hidden');
+            $('#messageHolder .loading').addClass('shown');
+        } else {
+            $('#messageHolder .loading').removeClass('shown');
+            $('#messageHolder #messages').removeClass('hidden');
+        }
+    }
+
+    updateAvatars() {
+        $.each($('.favicon:not(.loaded)'), (k, e) => {
+            let favicon = $(e);
+            favicon.addClass('loaded');
+            let d = favicon.data('domain');
+            let id = favicon.data('id');
+            let user = this.parent.userForID(id);
+
+            if (user.id) {
+                if (Object.keys(this.parent.avatars).includes(id)) {
+                    if (this.parent.avatars[id]) {
+                        let original = $(
+                            '#avatars .favicon[data-id=' + id + ']'
+                        );
+                        if (original.length) {
+                            let clone = original[0].cloneNode(true);
+                            let parent = favicon.parent();
+                            favicon.remove();
+                            parent.append(clone);
+                            //parent.find(".fallback").html('');
+                            this.updateOtherAvatars(id);
+                        }
+                    }
+                } else {
+                    this.parent.avatars[id] = false;
+                    let link = user.avatar;
+                    if (link) {
+                        link = `https://${window.location.host}/avatar/${user.id}`;
+                        let img = $('<img class="loading" />');
+                        img.attr('src', link)
+                            .on('load', (i) => {
+                                let im = $(i.target);
+                                favicon.css(
+                                    'background-image',
+                                    'url(' + link + ')'
+                                );
+                                //favicon.parent().find(".fallback").html('');
+                                im.remove();
+                                this.parent.avatars[id] = link;
+                                let clone = favicon[0].cloneNode(true);
+                                $('#avatars').append(clone);
+                                this.updateOtherAvatars(user.id);
+                            })
+                            .on('error', (r) => {
+                                $(r.target).remove();
+                                //this.parent.avatars[id] = false;
+                            });
+                        $('html').append(img);
+                    } else {
+                        this.parent.avatars[id] = false;
+                    }
+                }
+            }
+        });
+    }
+
+    updateOtherAvatars(id) {
+        if (this.parent.avatars[id]) {
+            let avatars = [
+                $(
+                    `#conversations .section.pms .avatar .favicon[data-id=${id}].loaded`
+                ),
+                $(`.messageHeader .avatar .favicon[data-id=${id}].loaded`),
+                $(
+                    `#messages .messageRow .avatar .favicon[data-id=${id}].loaded`
+                ),
+                $(`#users .user .avatar .favicon[data-id=${id}].loaded`),
+                $(
+                    `.contextMenu[data-name=userContext] .avatar .favicon[data-id=${id}].loaded`
+                ),
+                $(`.header .avatar .favicon[data-id=${id}].loaded`),
+                $(`#videoInfo .users .avatar .favicon[data-id=${id}].loaded`),
+            ];
+
+            $.each(avatars, (k, avatar) => {
+                if (avatar.length) {
+                    $.each(avatar, (k, a) => {
+                        a = $(a);
+                        if (
+                            a.css('background-image') === 'none' ||
+                            !a.css('background-image')
+                        ) {
+                            let original = $(
+                                '#avatars .favicon[data-id=' + id + ']'
+                            );
+                            if (original.length) {
+                                let clone = original[0].cloneNode(true);
+                                let parent = a.parent();
+                                a.remove();
+                                parent.append(clone);
+                                //parent.find(".fallback").html('');
+                            }
+                        }
+                    });
+                }
+            });
+        }
+    }
+
+    setContextMenuPosition(menu, e) {
+        if (!this.isDesktop()) {
+            return;
+        }
+
+        let hx = window.innerWidth / 2;
+        let hy = window.innerHeight / 2;
+        let x = e.clientX;
+        let y = e.clientY;
+
+        if (x >= hx) {
+            x = e.clientX - menu.outerWidth();
+        }
+        if (y >= hy) {
+            y = e.clientY - menu.outerHeight();
+        }
+
+        menu.css({ top: y, left: x });
+    }
+
+    setCaretPosition(ctrl, pos) {
+        if (ctrl.setSelectionRange) {
+            ctrl.focus();
+            ctrl.setSelectionRange(pos, pos);
+        } else if (ctrl.createTextRange) {
+            let range = ctrl.createTextRange();
+            range.collapse(true);
+            range.moveEnd('character', pos);
+            range.moveStart('character', pos);
+            range.select();
+        } else {
+            var range = document.createRange();
+            var selection = window.getSelection();
+            range.setStart(ctrl[0].childNodes[0], pos);
+            range.collapse(true);
+            selection.removeAllRanges();
+            selection.addRange(range);
+        }
+    }
+
+    categoryForEmoji(emoji) {
+        let cat = false;
+        $.each(Object.keys(this.emojiCategories), (k, category) => {
+            let data = this.emojiCategories[category];
+            if (data.includes(emoji.category)) {
+                cat = category;
+                return false;
+            }
+        });
+
+        if (cat) {
+            return cat;
+        }
+
+        return false;
+    }
+
+    setupReactView(e, sender) {
+        let target = $(e.target);
+        let action = target.data('action');
+
+        let menu = $('.popover[data-name=react]');
+        if (!sender) {
+            sender = '';
+        }
+        this.setData(menu, 'sender', sender);
+
+        menu.find('.tab[data-name=categories]').addClass('hidden');
+        menu.find('.tab[data-name=gifs]').addClass('hidden');
+
+        if (sender) {
+            let row = $(`.messageRow[data-id=${sender}]`);
+
+            if (!row.length) {
+                let id = target
+                    .closest('.body')
+                    .find('span.message')
+                    .data('id');
+                row = $('#messages').find(`.messageRow[data-id=${id}]`);
+            }
+
+            $('#holder').addClass('reacting');
+            $(`.messageRow`).removeClass('selected');
+            $('.messageRow').removeClass('selecting');
+            row.addClass('selected');
+
+            let hover = row.find('.hover');
+            hover.addClass('visible');
+            menu.addClass('react');
+            this.setContextMenuPosition(menu, e);
+        } else {
+            menu.find('.tab[data-name=gifs]').removeClass('hidden');
+            menu.removeClass('react');
+            menu.css({ top: 'auto' });
+        }
+
+        if (!menu.hasClass('loaded')) {
+            let data = {
+                action: 'getGifCategories',
+            };
+            this.parent.api(data).then((r) => {
+                if (r.success) {
+                    $.each(r.categories, (k, c) => {
+                        let category = $(`
 							<div class="category" data-term=${c.term}>
 								<div class="title">${c.term}</div>
 								<div class="background" style="background-image: url(${c.gif})"></div>
 							</div>
 						`);
-						menu.find(".section[data-type=categories]").append(category);
-					});
-				}
-			});
+                        menu.find('.section[data-type=categories]').append(
+                            category
+                        );
+                    });
+                }
+            });
 
-			$.each(Object.keys(this.emojiCategories), (k, category) => {
-				let section = $(`
+            $.each(Object.keys(this.emojiCategories), (k, category) => {
+                let section = $(`
 					<div class="section" data-name="${category}">
 						<div class="subtitle">${category}</div>
 						<div class="emojis"></div>
 					</div>
 				`);
 
-				if (k == 0) {
-					section.addClass("hidden");
-				}
-
-				menu.find(".body .grid[data-type=emojis]").append(section);
-			});
-
-			$.each(emojis, (k, emoji) => {
-				let category = this.categoryForEmoji(emoji);
-				let item = $(`<div class="emoji" data-aliases=${JSON.stringify(emoji.aliases)}>${emoji.emoji}</div>`);
-				menu.find(`.body .grid[data-type=emojis] .section[data-name=${category}] .emojis`).append(item);
-			});
-
-			menu.addClass("loaded");
-		}
-
-		this.switchReactTab(action);
-	}
-
-	switchReactTab(tab) {
-		let menu = $(".popover[data-name=react]");
-
-		menu.find(`.tabs .tab`).removeClass("active");
-		menu.find(".search input[name=searchGifs]").removeClass("shown");
-		menu.find(".search input[name=searchEmojis]").removeClass("shown");
-		menu.find(`.grid`).removeClass("shown");
-
-		menu.find(`.tabs .tab[data-name=${tab}]`).addClass("active");
-		menu.find(`.grid[data-type=${tab}]`).addClass("shown");
-
-		switch (tab) {
-			case "gifs":
-				menu.find(".search input[name=searchGifs]").addClass("shown");
-				break;
-
-			case "emojis":
-				menu.find(".search input[name=searchEmojis]").addClass("shown");
-				break;
-		}
-	}
-
-	searchGifs(query) {
-		let menu = $(".popover[data-name=react]");
-		menu.find(".section[data-type=gifs] .column").empty();
-
-		if (query.length) {
-			let data = {
-				action: "searchGifs",
-				query: query
-			}
-			this.parent.api(data).then(r => {
-				if (r.success) {
-					let column;
-					let col0 = 0;
-					let col1 = 0;
-					$.each(r.gifs, (k, g) => {
-						if (col0 > col1) {
-							column = 1;
-							col1 += g.height;
-						}
-						else {
-							column = 0;
-							col0 += g.height;
-						}
-						let gif = $(`<img class="gif" src="${g.preview}" data-id="${g.id}" data-full="${g.full}"></div>`);
-						menu.find(`.section[data-type=gifs] .column[data-column=${column}]`).append(gif);
-					});
-				}
-				this.shouldShowGifs();
-			});
-		}
-		else {
-			this.shouldShowGifs();
-		}
-	}
-
-	shouldShowGifs() {
-		let menu = $(".popover[data-name=react]");
-
-		if (menu.find(".gif").length) {
-			menu.find(".section[data-type=categories]").addClass("hidden");
-			menu.find(".section[data-type=gifs]").addClass("shown");
-		}
-		else {
-			menu.find(".section[data-type=gifs]").removeClass("shown");
-			menu.find(".section[data-type=categories]").removeClass("hidden");
-		}
-	}
-
-	handleDoubleClick(target) {
-		let id = target.data("id");
-
-		let type;
-		if (target.hasClass("inline channel")) {
-			type = "channel";
-		}
-		else {
-			type = "user";
-		}
-
-		switch (type) {
-			case "user":
-				let name = this.parent.userForID(id).domain;
-				let puny = `${this.toUnicode(name)}/`;
-				$(`.popover[data-name=newConversation] input[name=domain]`).val(puny);
-				this.popover("newConversation");
-				break;
-
-			case "channel":
-				$(`#conversations .channels tr[data-id=${id}]`).click();
-				break;
-		}
-	}
-
-	handleRightClick(e, target) {
-		let me = this.parent.userForID(this.parent.domain);
-		let isChannel = this.parent.isChannel(this.parent.conversation);
-		
-		let channel = {};
-		let isAdmin = false;
-		if (isChannel) {
-			channel = this.parent.channelForID(this.parent.conversation);
-			isAdmin = this.isAdmin(channel, me);
-		}
-
-		if (target.hasClass("fallback")) {
-			target = target.parent().find(".favicon");
-		}
-
-		if (target.hasClass("user") || target.hasClass("favicon") || target.hasClass("inline nick")) {
-			let id = target.data("id");	
-			let user = this.parent.userForID(id);
-			let domain = this.toUnicode(user.domain);
-			let joined = new Date(user.created * 1000).format(this.parent.dateFormat);
-			let bio = null;
-			if (user.bio) {
-				bio = he.encode(user.bio)
-			}
-
-			let avatar = this.avatar("div", id, user.domain, true);
-
-			let userList = target.closest("#users").length;
-			if (userList) {
-				$(`#users .user[data-id=${id}]`).addClass("selected");
-			}
-
-			let menu = $(".popover[data-name=userContext]");
-			menu.find(".pic").html(avatar);
-			this.setData(menu, "id", id);
-			this.setData(menu, "type", user.type);
-			menu.find("span.user").html(domain);
-			
-			menu.find("li.bio").addClass("hidden");
-
-			if (bio || id == this.parent.domain) {
-				menu.find("li.bio").removeClass("hidden");
-			}
-
-			if (id == this.parent.domain) {
-				menu.addClass("me");
-			}
-			else {
-				menu.removeClass("me");
-			}
-
-			menu.find("li.action.speaker").addClass("hidden");
-			if (channel.video && (isAdmin && user.active && !Object.keys(this.parent.currentVideoUsers()).includes(id))) {
-				menu.find("li.action.speaker").removeClass("hidden");
-			}
-
-			menu.find("div.bio").html(bio);
-			menu.find("span.joined").html(joined);
-			this.updateAvatars();
-			this.linkify($(".contextMenu[data-name=userContext] div.bio"));
-			this.popover("userContext");
-			this.setContextMenuPosition(menu, e);
-		}
-		else if (target.hasClass("inline channel")) {
-			let id = target.data("id");
-			let channel = this.parent.channelForID(id);
-			let name = `#${this.toUnicode(channel.name)}`;
-			let menu = $(".popover[data-name=channelContext]");
-			this.setData(menu, "id", id);
-			menu.find("span.channel").html(name);
-			this.popover("channelContext");
-			this.setContextMenuPosition(menu, e);
-		}
-		else if (target.closest(".messageRow").length) {
-			let message = target.closest(".messageRow");
-
-			if (message.hasClass("informational")) {
-				return;
-			}
-
-			$(".messageRow").removeClass("selecting");
-			message.addClass("selecting");
-			let menu = $(".popover[data-name=messageContext]");
-			this.setData(menu, "id", message.data("id"));
-			this.setData(menu, "sender", message.data("sender"));
-
-			menu.find("li.action.pin").addClass("hidden");
-			menu.find("li.action.delete").addClass("hidden");
-			if (isChannel) {
-				if (isAdmin) {
-					menu.find("li.action.pin").removeClass("hidden");
-					menu.find("li.action.delete").removeClass("hidden");
-				}
-			}
-
-			this.popover("messageContext");
-			this.setContextMenuPosition(menu, e);
-		}
-	}
-
-	changeConversation(id) {
-		$(`#conversations .sections tr[data-id=${id}]`).click();
-	}
-
-	updateTypingView() {
-		let typers = [];
-
-		$.each(this.parent.typers, (typer, data) => {
-			if ((this.parent.time() - data.time) <= this.parent.typingDelay) {
-				let name = this.toUnicode(this.parent.userForID(typer).domain);
-
-				if (data.to == this.parent.conversation) {
-					typers.push(`<span>${name}</span>`);
-				}
-			}
-			else {
-				delete this.parent.typers[typer];
-			}
-		});
-
-		let message;
-		if (typers.length) {
-			if (typers.length > 1) {
-				if (typers.length > 5) {
-					message = "Many users are typing...";
-				}
-				else {
-					let beginning = typers.slice(0, typers.length - 1);
-					let last = typers.pop();
-					message = `${beginning.join(", ")} and ${last} are typing...`;
-				}
-			}
-			else {
-				message = `${typers[0]} is typing...`;
-			}
-			$("#typing .message").html(message);
-			$("#typing").addClass("shown");
-		}
-		else {
-			$("#typing").removeClass("shown");
-		}
-	}
-
-	updateMentions(channels) {
-		$.each(channels, (k, channel) => {
-			$(`#conversations tr[data-id=${channel}]`).addClass("mentions");
-		});
-	}
-
-	hasBob() {
-		$("body").addClass("bob");
-	}
-
-	paymentResponse(data) {
-		let address = data.address;
-		let popover = $(".popover[data-name=pay]");
-		popover.find(".loading").removeClass("shown");
-		popover.find(".content").addClass("shown");
-
-		if (address) {
-			popover.find("input[name=address]").val(address);
-			popover.find("input").removeClass("hidden");
-			popover.find(".button").removeClass("hidden");
-		}
-		else {
-			popover.find("input").addClass("hidden");
-			popover.find(".button").addClass("hidden");
-			popover.find(".response").addClass("error");
-			popover.find(".response").html(data.message);
-		}
-	}
-
-	enableTarget(el) {
-		el.removeClass("disabled");
-	}
-
-	enableButton(type) {
-		$(`.button[data-action="${type}" i]`).removeClass("disabled");
-	}
-
-	handleSuccess(body) {
-		switch (body.type) {
-			case "ADDDOMAIN":
-			case "ADDSLD":
-				this.parent.changeDomain(body.id);
-				this.parent.ws.send("DOMAINS");
-				break;
-
-			case "VERIFYDOMAIN":
-				$(`.section#manageDomains .domain[data-id=${body.id}] .action[data-action=verifyDomain]`).remove();
-				break;
-		}
-	}
-
-	errorResponse(body) {
-		if (!body.message) {
-			body.message = "An unknown error occurred.";
-		}
-
-		switch (body.type) {
-			case "PM":
-			case "startConversation":
-				$(".popover[data-name=newConversation] .response").html(body.message);
-				break;
-
-			case "ADDSLD":
-			case "ADDDOMAIN":
-				$(".section#addDomain .response").html(body.message);
-				break;
-
-			case "sendPayment":
-				$(".popover[data-name=pay] .response").html(body.message);
-				break;
-
-			case "saveSettings":
-				$(".popover[data-name=settings] .response").html(body.message);
-				break;
-		}
-	}
-
-	closeMenusIfNeeded() {
-		$("#conversations").removeClass("showing");
-		$("#users").removeClass("showing");
-		$("body").removeClass("menu");
-	}
-
-	searchUsers(bool) {
-		if (bool) {
-			$("#users #count").addClass("hidden");
-			$("#users .group.normal").addClass("hidden");
-			$("#users .group.searching").addClass("shown");
-			$("#users .group.searching input").focus();
-		}
-		else {
-			$("#users .group.searching").removeClass("shown");
-			$("#users .group.normal").removeClass("hidden");
-			$("#users tr.user").removeClass("hidden");
-			$("#users #count").removeClass("hidden");
-			$("#users input[name=search]").val('');
-		}
-	}
-
-	queryUsers(query) {
-		let users = $("#users tr.user");
-
-		$.each(users, (k, user) => {
-			let match = Array.from(this.toUnicode($(user).data("name").toString())).slice(0, Array.from(query).length).join("").toLowerCase();
-			let search = query.toLowerCase();
-
-			if (match == search) {
-				$(user).removeClass("hidden");
-			}
-			else {
-				$(user).addClass("hidden");
-			}
-		});
-	}
-
-	showOrHideAttachments() {
-		let attachments = $("#attachments");
-		if (!attachments.find(".attachment").length) {
-			attachments.removeClass("shown");
-		}
-		else {
-			attachments.addClass("shown");
-			this.fixScroll();
-		}
-	}
-
-	setupNotifications() {
-		if ('Notification' in window && navigator.serviceWorker) {
-			if (!(Notification.permission === "granted" || Notification.permission === "blocked")) {
-				Notification.requestPermission(e => {
-					if (e === "granted") {
-						if ('serviceWorker' in navigator) {
-							navigator.serviceWorker.register('/sw.js', {
-								scope: '/',
-							});
-						}
-					}
-				});
-			} 
-		}
-	}
-
-	sendNotification(title, body, conversation) {
-		if ('Notification' in window && navigator.serviceWorker) {
-			if (Notification.permission == 'granted') {
-				navigator.serviceWorker.getRegistration().then(reg => {
-					let sound = new Audio("/assets/sound/pop");
-					sound.play();
-
-					var options = {
-						body: body,
-						icon: '/assets/img/logo.png',
-						vibrate: [100, 50, 100],
-						data: {
-							dateOfArrival: this.parent.time(),
-							primaryKey: 1
-						},
-						conversation: conversation
-					};
-
-					var notification = new Notification(title, options);
-					notification.onclick = () => {
-						this.parent.changeConversation(conversation);
-						window.focus();
-					};
-				});
-			}
-		}
-	}
-
-	stripHTML(string) {
-		var div = document.createElement("div");
-		div.innerHTML = string.replace("<div>", "\n");
-		var text = div.textContent || div.innerText || "";
-		return text.trim();
-	}
-
-	clearSelection() {
-		if (window.getSelection) {
-			window.getSelection().removeAllRanges();
-		}
-		else if (document.selection) {
-			document.selection.empty();
-		}
-	}
-
-	getBrowser() {
-		var browser = (function() {
-		    var test = function(regexp) {return regexp.test(window.navigator.userAgent)}
-		    switch (true) {
-		        case test(/edg/i): return "Microsoft Edge";
-		        case test(/trident/i): return "Microsoft Internet Explorer";
-		        case test(/firefox|fxios/i): return "Mozilla Firefox";
-		        case test(/opr\//i): return "Opera";
-		        case test(/ucbrowser/i): return "UC Browser";
-		        case test(/samsungbrowser/i): return "Samsung Browser";
-		        case test(/chrome|chromium|crios/i): return "Google Chrome";
-		        case test(/safari/i): return "Apple Safari";
-		        default: return "Other";
-		    }
-		})();
-
-		return browser;
-	};
-
-	fixScroll() {
-		switch (this.browser) {
-			case "Apple Safari":
-				let messageHolder = $("#messageHolder");
-				let scrollTop = messageHolder[0].scrollTop;
-
-				if (scrollTop >= 0) {
-					messageHolder.scrollTop(-1);
-					messageHolder.scrollTop(0);
-				}
-				break;
-		}
-	}
-
-	scrollToMessage(id) {
-		let messageHolder = $("#messageHolder");
-		$(`.messageRow[data-id=${id}]`)[0].scrollIntoView({ behavior: 'smooth', block: 'start', inline: "nearest" });
-	}
-
-	highlightMessage(id) {
-		$(`.messageRow[data-id=${id}]`).addClass("highlighted");
-		setTimeout(() => {
-			$(`.messageRow[data-id=${id}]`).removeClass("highlighted");
-		}, 3000);
-	}
-
-	handleHash() {
-		let hash = this.parent.hash;
-		if (!hash) {
-			return;
-		}
-		hash = hash.toLowerCase().trim();
-		let split = hash.split(":");
-		let action = split[0];
-		let param = split[1];
-		
-		switch (action) {
-			case "message":
-				if (param) {
-					let puny = `${this.toUnicode(param)}/`;
-					$(`.popover[data-name=newConversation] input[name=domain]`).val(puny);
-					this.popover("newConversation");
-				}
-				break;
-
-			case "channel":
-				let channel = this.parent.channelForName(param);
-				if (channel) {
-					this.parent.changeConversation(channel.id);
-				}
-				break;
-		}
-
-		localStorage.removeItem("hash");
-	}
-
-	tabComplete() {
-		let prefix = "";
-		let suffix = "";
-
-		var text = $("#message").val();
-
-		var options = [];
-		if (text[0] === "/") {
-			if (text.length > 1 && text[1] !== "/") {
-				prefix = "/";
-				suffix = " ";
-				options = this.parent.commands;
-
-				text = text.substring(1);
-
-			}
-		}
-		else {
-			return;
-		}
-
-		options.sort();
-
-		let matches = options.filter(option => {
-			option = String(option);
-
-			if (option.length) {
-				return option.substr(0, text.length).toLowerCase() == text.toLowerCase();
-			}
-			return;
-		});
-
-		if (matches.length) {
-			$("#message").val(prefix+matches[0]+suffix);
-		}
-	}
-
-	editProfile() {
-		let menu = $(".contextMenu[data-name=userContext]");
-		menu.addClass("editing");
-
-		let bio = menu.find("div.bio");
-		let bioText = this.sanitizeContentEditable(bio[0]);
-		bio.html(he.encode(bioText));
-		bio.attr("contenteditable", true);
-		bio.focus();
-
-		if (bioText.length) {
-			this.setCaretPosition(bio, bioText.length);
-		}
-
-		this.updateBioLimit();
-	}
-
-	saveProfile() {
-		let menu = $(".contextMenu[data-name=userContext]");
-		menu.removeClass("editing");
-
-		let bio = menu.find("div.bio");
-		let bioText = this.sanitizeContentEditable(bio[0]);
-		bio.html(he.encode(bioText));
-		bio.attr("contenteditable", false);
-		this.linkify(bio);
-
-		let data = {
-			bio: bioText
-		}
-		this.parent.ws.send(`SAVEPROFILE ${JSON.stringify(data)}`);
-	}
-
-	undoProfile() {
-		let menu = $(".contextMenu[data-name=userContext].me.editing");
-		if (menu.length) {
-			menu.removeClass("editing");
-
-			let bio = menu.find("div.bio");
-			let id = menu.data("id");
-			let user = this.parent.userForID(id);
-			let bioText = user.bio;
-			if (bioText) {
-				bioText = he.encode(bioText);
-			}
-			bio.html(bioText);
-			bio.attr("contenteditable", false);
-			this.linkify(bio);
-		}
-	}
-
-	updateBioLimit(e) {
-		let menu = $(".contextMenu[data-name=userContext]");
-		let bio = menu.find("div.bio").text();
-		let save = menu.find(".action.save");
-		let max = 140;
-
-		let string = `${bio.length} / ${max}`;
-		let limit = menu.find(".bioHolder .limit");
-		limit.html(string);
-
-		if (bio.length > max) {
-			save.addClass("disabled");
-			limit.addClass("error");
-		}
-		else {
-			save.removeClass("disabled");
-			limit.removeClass("error");
-		}
-	}
-
-	sanitizeContentEditable(el) {
-		let value = "";
-		let newLine = true;
-
-		let nodes = el.childNodes;
-
-		if (nodes) {
-		 	nodes.forEach(node => {
-		 		if (node.nodeName === "BR") {
-		 			value += "\n";
-		 			newLine = true;
-		 			return;
-		 		}
-
-		 		if (node.nodeName === "DIV" && newLine == false) {
-		 			value += "\n";
-		 		}
-
-		 		newLine = false;
-
-		 		if (node.nodeType === 3 && node.textContent) {
-		 			value += node.textContent;
-		 		}
-
-		 		if (node.childNodes) {
-			 		value += this.sanitizeContentEditable(node);
-			 	}
-
-		 	});
-		 }
-
-	 	return value.trim();
-	}
-
-	checkVersion(version) {
-		if (!this.updateAvailable && this.version !== version) {
-			this.updateAvailable = true;
-			this.popover("update");
-		}
-	}
-
-	newTab(e) {
-		if (e && ((e.ctrlKey || e.metaKey) || e.button == 1)) {
-			return true;
-		}
-		return false;
-	}
-
-	openURL(page, e=null) {
-		if (e && (this.newTab(e) || e.newTab)) {
-			window.open(page, "_blank");
-		}
-		else {
-			window.location = page;
-		}
-	}
-
-	avatar(type, id, domain, status=false) {
-		let user = this.parent.userForID(id)
-		let puny = this.toUnicode(domain);
-
-		let active = "";
-		if (user.active) {
-			active = " active";
-		}
-
-		let statusHTML = "";
-		if (status) {
-			statusHTML = `<div class="status${active}"></div>`;
-		}
-
-		return `
+                if (k == 0) {
+                    section.addClass('hidden');
+                }
+
+                menu.find('.body .grid[data-type=emojis]').append(section);
+            });
+
+            $.each(emojis, (k, emoji) => {
+                let category = this.categoryForEmoji(emoji);
+                let item = $(
+                    `<div class="emoji" data-aliases=${JSON.stringify(
+                        emoji.aliases
+                    )}>${emoji.emoji}</div>`
+                );
+                menu.find(
+                    `.body .grid[data-type=emojis] .section[data-name=${category}] .emojis`
+                ).append(item);
+            });
+
+            menu.addClass('loaded');
+        }
+
+        this.switchReactTab(action);
+    }
+
+    switchReactTab(tab) {
+        let menu = $('.popover[data-name=react]');
+
+        menu.find(`.tabs .tab`).removeClass('active');
+        menu.find('.search input[name=searchGifs]').removeClass('shown');
+        menu.find('.search input[name=searchEmojis]').removeClass('shown');
+        menu.find(`.grid`).removeClass('shown');
+
+        menu.find(`.tabs .tab[data-name=${tab}]`).addClass('active');
+        menu.find(`.grid[data-type=${tab}]`).addClass('shown');
+
+        switch (tab) {
+            case 'gifs':
+                menu.find('.search input[name=searchGifs]').addClass('shown');
+                break;
+
+            case 'emojis':
+                menu.find('.search input[name=searchEmojis]').addClass('shown');
+                break;
+        }
+    }
+
+    searchGifs(query) {
+        let menu = $('.popover[data-name=react]');
+        menu.find('.section[data-type=gifs] .column').empty();
+
+        if (query.length) {
+            let data = {
+                action: 'searchGifs',
+                query: query,
+            };
+            this.parent.api(data).then((r) => {
+                if (r.success) {
+                    let column;
+                    let col0 = 0;
+                    let col1 = 0;
+                    $.each(r.gifs, (k, g) => {
+                        if (col0 > col1) {
+                            column = 1;
+                            col1 += g.height;
+                        } else {
+                            column = 0;
+                            col0 += g.height;
+                        }
+                        let gif = $(
+                            `<img class="gif" src="${g.preview}" data-id="${g.id}" data-full="${g.full}"></div>`
+                        );
+                        menu.find(
+                            `.section[data-type=gifs] .column[data-column=${column}]`
+                        ).append(gif);
+                    });
+                }
+                this.shouldShowGifs();
+            });
+        } else {
+            this.shouldShowGifs();
+        }
+    }
+
+    shouldShowGifs() {
+        let menu = $('.popover[data-name=react]');
+
+        if (menu.find('.gif').length) {
+            menu.find('.section[data-type=categories]').addClass('hidden');
+            menu.find('.section[data-type=gifs]').addClass('shown');
+        } else {
+            menu.find('.section[data-type=gifs]').removeClass('shown');
+            menu.find('.section[data-type=categories]').removeClass('hidden');
+        }
+    }
+
+    handleDoubleClick(target) {
+        let id = target.data('id');
+
+        let type;
+        if (target.hasClass('inline channel')) {
+            type = 'channel';
+        } else {
+            type = 'user';
+        }
+
+        switch (type) {
+            case 'user':
+                let name = this.parent.userForID(id).domain;
+                let puny = `${this.toUnicode(name)}/`;
+                $(`.popover[data-name=newConversation] input[name=domain]`).val(
+                    puny
+                );
+                this.popover('newConversation');
+                break;
+
+            case 'channel':
+                $(`#conversations .channels tr[data-id=${id}]`).click();
+                break;
+        }
+    }
+
+    handleRightClick(e, target) {
+        let me = this.parent.userForID(this.parent.domain);
+        let isChannel = this.parent.isChannel(this.parent.conversation);
+
+        let channel = {};
+        let isAdmin = false;
+        if (isChannel) {
+            channel = this.parent.channelForID(this.parent.conversation);
+            isAdmin = this.isAdmin(channel, me);
+        }
+
+        if (target.hasClass('fallback')) {
+            target = target.parent().find('.favicon');
+        }
+
+        if (
+            target.hasClass('user') ||
+            target.hasClass('favicon') ||
+            target.hasClass('inline nick')
+        ) {
+            let id = target.data('id');
+            let user = this.parent.userForID(id);
+            let domain = this.toUnicode(user.domain);
+            let joined = new Date(user.created * 1000).format(
+                this.parent.dateFormat
+            );
+            let bio = null;
+            if (user.bio) {
+                bio = he.encode(user.bio);
+            }
+
+            let avatar = this.avatar('div', id, user.domain, true);
+
+            let userList = target.closest('#users').length;
+            if (userList) {
+                $(`#users .user[data-id=${id}]`).addClass('selected');
+            }
+
+            let menu = $('.popover[data-name=userContext]');
+            menu.find('.pic').html(avatar);
+            this.setData(menu, 'id', id);
+            this.setData(menu, 'type', user.type);
+            menu.find('span.user').html(domain);
+
+            menu.find('li.bio').addClass('hidden');
+
+            if (bio || id == this.parent.domain) {
+                menu.find('li.bio').removeClass('hidden');
+            }
+
+            if (id == this.parent.domain) {
+                menu.addClass('me');
+            } else {
+                menu.removeClass('me');
+            }
+
+            menu.find('li.action.speaker').addClass('hidden');
+            if (
+                channel.video &&
+                isAdmin &&
+                user.active &&
+                !Object.keys(this.parent.currentVideoUsers()).includes(id)
+            ) {
+                menu.find('li.action.speaker').removeClass('hidden');
+            }
+
+            menu.find('div.bio').html(bio);
+            menu.find('span.joined').html(joined);
+            this.updateAvatars();
+            this.linkify($('.contextMenu[data-name=userContext] div.bio'));
+            this.popover('userContext');
+            this.setContextMenuPosition(menu, e);
+        } else if (target.hasClass('inline channel')) {
+            let id = target.data('id');
+            let channel = this.parent.channelForID(id);
+            let name = `#${this.toUnicode(channel.name)}`;
+            let menu = $('.popover[data-name=channelContext]');
+            this.setData(menu, 'id', id);
+            menu.find('span.channel').html(name);
+            this.popover('channelContext');
+            this.setContextMenuPosition(menu, e);
+        } else if (target.closest('.messageRow').length) {
+            let message = target.closest('.messageRow');
+
+            if (message.hasClass('informational')) {
+                return;
+            }
+
+            $('.messageRow').removeClass('selecting');
+            message.addClass('selecting');
+            let menu = $('.popover[data-name=messageContext]');
+            this.setData(menu, 'id', message.data('id'));
+            this.setData(menu, 'sender', message.data('sender'));
+
+            menu.find('li.action.pin').addClass('hidden');
+            menu.find('li.action.delete').addClass('hidden');
+            if (isChannel) {
+                if (isAdmin) {
+                    menu.find('li.action.pin').removeClass('hidden');
+                    menu.find('li.action.delete').removeClass('hidden');
+                }
+            }
+
+            this.popover('messageContext');
+            this.setContextMenuPosition(menu, e);
+        }
+    }
+
+    changeConversation(id) {
+        $(`#conversations .sections tr[data-id=${id}]`).click();
+    }
+
+    updateTypingView() {
+        let typers = [];
+
+        $.each(this.parent.typers, (typer, data) => {
+            if (this.parent.time() - data.time <= this.parent.typingDelay) {
+                let name = this.toUnicode(this.parent.userForID(typer).domain);
+
+                if (data.to == this.parent.conversation) {
+                    typers.push(`<span>${name}</span>`);
+                }
+            } else {
+                delete this.parent.typers[typer];
+            }
+        });
+
+        let message;
+        if (typers.length) {
+            if (typers.length > 1) {
+                if (typers.length > 5) {
+                    message = 'Many users are typing...';
+                } else {
+                    let beginning = typers.slice(0, typers.length - 1);
+                    let last = typers.pop();
+                    message = `${beginning.join(
+                        ', '
+                    )} and ${last} are typing...`;
+                }
+            } else {
+                message = `${typers[0]} is typing...`;
+            }
+            $('#typing .message').html(message);
+            $('#typing').addClass('shown');
+        } else {
+            $('#typing').removeClass('shown');
+        }
+    }
+
+    updateMentions(channels) {
+        $.each(channels, (k, channel) => {
+            $(`#conversations tr[data-id=${channel}]`).addClass('mentions');
+        });
+    }
+
+    hasBob() {
+        $('body').addClass('bob');
+    }
+
+    paymentResponse(data) {
+        let address = data.address;
+        let popover = $('.popover[data-name=pay]');
+        popover.find('.loading').removeClass('shown');
+        popover.find('.content').addClass('shown');
+
+        if (address) {
+            popover.find('input[name=address]').val(address);
+            popover.find('input').removeClass('hidden');
+            popover.find('.button').removeClass('hidden');
+        } else {
+            popover.find('input').addClass('hidden');
+            popover.find('.button').addClass('hidden');
+            popover.find('.response').addClass('error');
+            popover.find('.response').html(data.message);
+        }
+    }
+
+    enableTarget(el) {
+        el.removeClass('disabled');
+    }
+
+    enableButton(type) {
+        $(`.button[data-action="${type}" i]`).removeClass('disabled');
+    }
+
+    handleSuccess(body) {
+        switch (body.type) {
+            case 'ADDDOMAIN':
+            case 'ADDSLD':
+                this.parent.changeDomain(body.id);
+                this.parent.ws.send('DOMAINS');
+                break;
+
+            case 'VERIFYDOMAIN':
+                $(
+                    `.section#manageDomains .domain[data-id=${body.id}] .action[data-action=verifyDomain]`
+                ).remove();
+                break;
+        }
+    }
+
+    errorResponse(body) {
+        if (!body.message) {
+            body.message = 'An unknown error occurred.';
+        }
+
+        switch (body.type) {
+            case 'PM':
+            case 'startConversation':
+                $('.popover[data-name=newConversation] .response').html(
+                    body.message
+                );
+                break;
+
+            case 'ADDSLD':
+            case 'ADDDOMAIN':
+                $('.section#addDomain .response').html(body.message);
+                break;
+
+            case 'sendPayment':
+                $('.popover[data-name=pay] .response').html(body.message);
+                break;
+
+            case 'saveSettings':
+                $('.popover[data-name=settings] .response').html(body.message);
+                break;
+        }
+    }
+
+    closeMenusIfNeeded() {
+        $('#conversations').removeClass('showing');
+        $('#users').removeClass('showing');
+        $('body').removeClass('menu');
+    }
+
+    searchUsers(bool) {
+        if (bool) {
+            $('#users #count').addClass('hidden');
+            $('#users .group.normal').addClass('hidden');
+            $('#users .group.searching').addClass('shown');
+            $('#users .group.searching input').focus();
+        } else {
+            $('#users .group.searching').removeClass('shown');
+            $('#users .group.normal').removeClass('hidden');
+            $('#users tr.user').removeClass('hidden');
+            $('#users #count').removeClass('hidden');
+            $('#users input[name=search]').val('');
+        }
+    }
+
+    queryUsers(query) {
+        let users = $('#users tr.user');
+
+        $.each(users, (k, user) => {
+            let match = Array.from(
+                this.toUnicode($(user).data('name').toString())
+            )
+                .slice(0, Array.from(query).length)
+                .join('')
+                .toLowerCase();
+            let search = query.toLowerCase();
+
+            if (match == search) {
+                $(user).removeClass('hidden');
+            } else {
+                $(user).addClass('hidden');
+            }
+        });
+    }
+
+    showOrHideAttachments() {
+        let attachments = $('#attachments');
+        if (!attachments.find('.attachment').length) {
+            attachments.removeClass('shown');
+        } else {
+            attachments.addClass('shown');
+            this.fixScroll();
+        }
+    }
+
+    setupNotifications() {
+        if ('Notification' in window && navigator.serviceWorker) {
+            if (
+                !(
+                    Notification.permission === 'granted' ||
+                    Notification.permission === 'blocked'
+                )
+            ) {
+                Notification.requestPermission((e) => {
+                    if (e === 'granted') {
+                        if ('serviceWorker' in navigator) {
+                            navigator.serviceWorker.register('/sw.js', {
+                                scope: '/',
+                            });
+                        }
+                    }
+                });
+            }
+        }
+    }
+
+    sendNotification(title, body, conversation) {
+        if ('Notification' in window && navigator.serviceWorker) {
+            if (Notification.permission == 'granted') {
+                navigator.serviceWorker.getRegistration().then((reg) => {
+                    let sound = new Audio('/assets/sound/pop');
+                    sound.play();
+
+                    var options = {
+                        body: body,
+                        icon: '/assets/img/logo.png',
+                        vibrate: [100, 50, 100],
+                        data: {
+                            dateOfArrival: this.parent.time(),
+                            primaryKey: 1,
+                        },
+                        conversation: conversation,
+                    };
+
+                    var notification = new Notification(title, options);
+                    notification.onclick = () => {
+                        this.parent.changeConversation(conversation);
+                        window.focus();
+                    };
+                });
+            }
+        }
+    }
+
+    stripHTML(string) {
+        var div = document.createElement('div');
+        div.innerHTML = string.replace('<div>', '\n');
+        var text = div.textContent || div.innerText || '';
+        return text.trim();
+    }
+
+    clearSelection() {
+        if (window.getSelection) {
+            window.getSelection().removeAllRanges();
+        } else if (document.selection) {
+            document.selection.empty();
+        }
+    }
+
+    getBrowser() {
+        var browser = (function () {
+            var test = function (regexp) {
+                return regexp.test(window.navigator.userAgent);
+            };
+            switch (true) {
+                case test(/edg/i):
+                    return 'Microsoft Edge';
+                case test(/trident/i):
+                    return 'Microsoft Internet Explorer';
+                case test(/firefox|fxios/i):
+                    return 'Mozilla Firefox';
+                case test(/opr\//i):
+                    return 'Opera';
+                case test(/ucbrowser/i):
+                    return 'UC Browser';
+                case test(/samsungbrowser/i):
+                    return 'Samsung Browser';
+                case test(/chrome|chromium|crios/i):
+                    return 'Google Chrome';
+                case test(/safari/i):
+                    return 'Apple Safari';
+                default:
+                    return 'Other';
+            }
+        })();
+
+        return browser;
+    }
+
+    fixScroll() {
+        switch (this.browser) {
+            case 'Apple Safari':
+                let messageHolder = $('#messageHolder');
+                let scrollTop = messageHolder[0].scrollTop;
+
+                if (scrollTop >= 0) {
+                    messageHolder.scrollTop(-1);
+                    messageHolder.scrollTop(0);
+                }
+                break;
+        }
+    }
+
+    scrollToMessage(id) {
+        let messageHolder = $('#messageHolder');
+        $(`.messageRow[data-id=${id}]`)[0].scrollIntoView({
+            behavior: 'smooth',
+            block: 'start',
+            inline: 'nearest',
+        });
+    }
+
+    highlightMessage(id) {
+        $(`.messageRow[data-id=${id}]`).addClass('highlighted');
+        setTimeout(() => {
+            $(`.messageRow[data-id=${id}]`).removeClass('highlighted');
+        }, 3000);
+    }
+
+    handleHash() {
+        let hash = this.parent.hash;
+        if (!hash) {
+            return;
+        }
+        hash = hash.toLowerCase().trim();
+        let split = hash.split(':');
+        let action = split[0];
+        let param = split[1];
+
+        switch (action) {
+            case 'message':
+                if (param) {
+                    let puny = `${this.toUnicode(param)}/`;
+                    $(
+                        `.popover[data-name=newConversation] input[name=domain]`
+                    ).val(puny);
+                    this.popover('newConversation');
+                }
+                break;
+
+            case 'channel':
+                let channel = this.parent.channelForName(param);
+                if (channel) {
+                    this.parent.changeConversation(channel.id);
+                }
+                break;
+        }
+
+        localStorage.removeItem('hash');
+    }
+
+    tabComplete() {
+        let prefix = '';
+        let suffix = '';
+
+        var text = $('#message').val();
+
+        var options = [];
+        if (text[0] === '/') {
+            if (text.length > 1 && text[1] !== '/') {
+                prefix = '/';
+                suffix = ' ';
+                options = this.parent.commands;
+
+                text = text.substring(1);
+            }
+        } else {
+            return;
+        }
+
+        options.sort();
+
+        let matches = options.filter((option) => {
+            option = String(option);
+
+            if (option.length) {
+                return (
+                    option.substr(0, text.length).toLowerCase() ==
+                    text.toLowerCase()
+                );
+            }
+            return;
+        });
+
+        if (matches.length) {
+            $('#message').val(prefix + matches[0] + suffix);
+        }
+    }
+
+    editProfile() {
+        let menu = $('.contextMenu[data-name=userContext]');
+        menu.addClass('editing');
+
+        let bio = menu.find('div.bio');
+        let bioText = this.sanitizeContentEditable(bio[0]);
+        bio.html(he.encode(bioText));
+        bio.attr('contenteditable', true);
+        bio.focus();
+
+        if (bioText.length) {
+            this.setCaretPosition(bio, bioText.length);
+        }
+
+        this.updateBioLimit();
+    }
+
+    saveProfile() {
+        let menu = $('.contextMenu[data-name=userContext]');
+        menu.removeClass('editing');
+
+        let bio = menu.find('div.bio');
+        let bioText = this.sanitizeContentEditable(bio[0]);
+        bio.html(he.encode(bioText));
+        bio.attr('contenteditable', false);
+        this.linkify(bio);
+
+        let data = {
+            bio: bioText,
+        };
+        this.parent.ws.send(`SAVEPROFILE ${JSON.stringify(data)}`);
+    }
+
+    undoProfile() {
+        let menu = $('.contextMenu[data-name=userContext].me.editing');
+        if (menu.length) {
+            menu.removeClass('editing');
+
+            let bio = menu.find('div.bio');
+            let id = menu.data('id');
+            let user = this.parent.userForID(id);
+            let bioText = user.bio;
+            if (bioText) {
+                bioText = he.encode(bioText);
+            }
+            bio.html(bioText);
+            bio.attr('contenteditable', false);
+            this.linkify(bio);
+        }
+    }
+
+    updateBioLimit(e) {
+        let menu = $('.contextMenu[data-name=userContext]');
+        let bio = menu.find('div.bio').text();
+        let save = menu.find('.action.save');
+        let max = 140;
+
+        let string = `${bio.length} / ${max}`;
+        let limit = menu.find('.bioHolder .limit');
+        limit.html(string);
+
+        if (bio.length > max) {
+            save.addClass('disabled');
+            limit.addClass('error');
+        } else {
+            save.removeClass('disabled');
+            limit.removeClass('error');
+        }
+    }
+
+    sanitizeContentEditable(el) {
+        let value = '';
+        let newLine = true;
+
+        let nodes = el.childNodes;
+
+        if (nodes) {
+            nodes.forEach((node) => {
+                if (node.nodeName === 'BR') {
+                    value += '\n';
+                    newLine = true;
+                    return;
+                }
+
+                if (node.nodeName === 'DIV' && newLine == false) {
+                    value += '\n';
+                }
+
+                newLine = false;
+
+                if (node.nodeType === 3 && node.textContent) {
+                    value += node.textContent;
+                }
+
+                if (node.childNodes) {
+                    value += this.sanitizeContentEditable(node);
+                }
+            });
+        }
+
+        return value.trim();
+    }
+
+    checkVersion(version) {
+        if (!this.updateAvailable && this.version !== version) {
+            this.updateAvailable = true;
+            this.popover('update');
+        }
+    }
+
+    newTab(e) {
+        if (e && (e.ctrlKey || e.metaKey || e.button == 1)) {
+            return true;
+        }
+        return false;
+    }
+
+    openURL(page, e = null) {
+        if (e && (this.newTab(e) || e.newTab)) {
+            window.open(page, '_blank');
+        } else {
+            window.location = page;
+        }
+    }
+
+    avatar(type, id, domain, status = false) {
+        let user = this.parent.userForID(id);
+        let puny = this.toUnicode(domain);
+
+        let active = '';
+        if (user.active) {
+            active = ' active';
+        }
+
+        let statusHTML = '';
+        if (status) {
+            statusHTML = `<div class="status${active}"></div>`;
+        }
+
+        return `
 			<${type} class="avatar">
 				${statusHTML}
 				<div class="favicon" data-id="${id}" data-domain="${domain}"></div>
 				<div class="fallback">${this.avatarFallback(puny)}</div>
 			</${type}>
 		`;
-	}
+    }
 
-	changeMe(id) {
-		let domain = this.parent.userForID(id).domain;
-		let avatar = this.avatar("td", id, domain);
-		$("#me").html(avatar);
-	}
+    changeMe(id) {
+        let domain = this.parent.userForID(id).domain;
+        let avatar = this.avatar('td', id, domain);
+        $('#me').html(avatar);
+    }
 
-	chatDisplayMode(mode) {
-		switch (mode) {
-			case "compact":
-				$("body").addClass("compact");
-				break;
+    chatDisplayMode(mode) {
+        switch (mode) {
+            case 'compact':
+                $('body').addClass('compact');
+                break;
 
-			default:
-				$("body").removeClass("compact");
-				break;
-		}
-	}
+            default:
+                $('body').removeClass('compact');
+                break;
+        }
+    }
 
-	isDesktop() {
-		return !$(".header .icon.menu").is(":visible");
-	}
+    isDesktop() {
+        return !$('.header .icon.menu').is(':visible');
+    }
 
-	isCompact() {
-		return $("body").hasClass("compact");
-	}
+    isCompact() {
+        return $('body').hasClass('compact');
+    }
 
-	async scanQR() {
-		let popover = $(".popover[data-name=qr]");
-		let loading = popover.find(".loading");
+    async scanQR() {
+        let popover = $('.popover[data-name=qr]');
+        let loading = popover.find('.loading');
 
-		this.getCameraFeed($("#camera")).then(() => {
-			loading.removeClass("shown");
-			this.lookForQR().then((qr) => {
-				this.openURL(qr);
-			});
-		});
-	}
+        this.getCameraFeed($('#camera')).then(() => {
+            loading.removeClass('shown');
+            this.lookForQR().then((qr) => {
+                this.openURL(qr);
+            });
+        });
+    }
 
-	async getCameraFeed(el, device) {
-		return new Promise(resolve => {
-			let videoEl = el[0];
-			let config = { 
-				video: { 
-					facingMode: "environment"
-				}
-			};
-			navigator.mediaDevices.getUserMedia(config).then(stream => {
-				videoEl.srcObject = stream;
-				videoEl.play();
+    async getCameraFeed(el, device) {
+        return new Promise((resolve) => {
+            let videoEl = el[0];
+            let config = {
+                video: {
+                    facingMode: 'environment',
+                },
+            };
+            navigator.mediaDevices.getUserMedia(config).then((stream) => {
+                videoEl.srcObject = stream;
+                videoEl.play();
 
-				videoEl.addEventListener('loadedmetadata', function() {
-					resolve();
-				});
-			});
-		});
-	}
+                videoEl.addEventListener('loadedmetadata', function () {
+                    resolve();
+                });
+            });
+        });
+    }
 
-	async lookForQR() {
-		return new Promise(resolve => {
-			let interval = setInterval(() => {
-				let canvasElement = $("#frame")[0];
-				let canvas = canvasElement.getContext("2d");
-				let videoEl = $("#camera")[0];
-				let height = $(videoEl).height() * 2;
-				let width = $(videoEl).width() * 2;
+    async lookForQR() {
+        return new Promise((resolve) => {
+            let interval = setInterval(() => {
+                let canvasElement = $('#frame')[0];
+                let canvas = canvasElement.getContext('2d');
+                let videoEl = $('#camera')[0];
+                let height = $(videoEl).height() * 2;
+                let width = $(videoEl).width() * 2;
 
-				canvas.drawImage(videoEl, 0, 0, canvasElement.width, canvasElement.height);
-		        var imageData = canvas.getImageData(0, 0, canvasElement.width, canvasElement.height);
-		        var code = jsQR(imageData.data, imageData.width, imageData.height);
+                canvas.drawImage(
+                    videoEl,
+                    0,
+                    0,
+                    canvasElement.width,
+                    canvasElement.height
+                );
+                var imageData = canvas.getImageData(
+                    0,
+                    0,
+                    canvasElement.width,
+                    canvasElement.height
+                );
+                var code = jsQR(
+                    imageData.data,
+                    imageData.width,
+                    imageData.height
+                );
 
-		        if (code) {
-		          clearInterval(interval);
-		          resolve(code.data);
-		        }
-			}, 100);
-		});
-	}
+                if (code) {
+                    clearInterval(interval);
+                    resolve(code.data);
+                }
+            }, 100);
+        });
+    }
 
-	async showVideoIfNeeded() {
-		$("#videoContainer").removeClass("shown");
-		$("#videoInfo .link").removeClass("shown");
-		$("#videoInfo .users").empty();
-		$("#videoInfo .watchers").empty();
-		$("#videoInfo .watching").removeClass("shown");
-		$("#videoInfo").removeClass("shown");
+    async showVideoIfNeeded() {
+        $('#videoContainer').removeClass('shown');
+        $('#videoInfo .link').removeClass('shown');
+        $('#videoInfo .users').empty();
+        $('#videoInfo .watchers').empty();
+        $('#videoInfo .watching').removeClass('shown');
+        $('#videoInfo').removeClass('shown');
 
-		if (!this.parent.isChannel(this.parent.conversation)) {
-			return;
-		}
+        if (!this.parent.isChannel(this.parent.conversation)) {
+            return;
+        }
 
-		let channel = this.parent.channelForID(this.parent.conversation);
-		let me = this.parent.userForID(this.parent.domain);
-		let active = channel.video;
-		let users = Object.keys(channel.videoUsers);
-		let speakers = channel.videoSpeakers;
-		let joined = users.includes(this.parent.domain);
-		let watchers = channel.videoWatchers;
-		let watching = channel.watching;
+        let channel = this.parent.channelForID(this.parent.conversation);
+        let me = this.parent.userForID(this.parent.domain);
+        let active = channel.video;
+        let users = Object.keys(channel.videoUsers);
+        let speakers = channel.videoSpeakers;
+        let joined = users.includes(this.parent.domain);
+        let watchers = channel.videoWatchers;
+        let watching = channel.watching;
 
-		if (active) {
-			$("#videoInfo .title").addClass("shown");
+        if (active) {
+            $('#videoInfo .title').addClass('shown');
 
-			$.each(users, (k, u) => {
-				let avatar = this.avatar("div", u, this.parent.userForID(u).domain);
-				$("#videoInfo .users").append(avatar);
-			});
-			$.each(watchers, (k, u) => {
-				if (!users.includes(u)) {
-					let avatar = this.avatar("div", u, this.parent.userForID(u).domain);
-					$("#videoInfo .watchers").append(avatar);
-				}
-			});
+            $.each(users, (k, u) => {
+                let avatar = this.avatar(
+                    'div',
+                    u,
+                    this.parent.userForID(u).domain
+                );
+                $('#videoInfo .users').append(avatar);
+            });
+            $.each(watchers, (k, u) => {
+                if (!users.includes(u)) {
+                    let avatar = this.avatar(
+                        'div',
+                        u,
+                        this.parent.userForID(u).domain
+                    );
+                    $('#videoInfo .watchers').append(avatar);
+                }
+            });
 
-			if ($("#videoInfo .watchers .avatar").length) {
-				$("#videoInfo .watching").addClass("shown");
-			}
+            if ($('#videoInfo .watchers .avatar').length) {
+                $('#videoInfo .watching').addClass('shown');
+            }
 
-			this.updateAvatars();
+            this.updateAvatars();
 
-			$("#videoInfo").addClass("shown");
+            $('#videoInfo').addClass('shown');
 
-			if (!watching) {
-				$("#videoInfo .link[data-action=viewVideo]").addClass("shown");
-			}
-		}
-		
-		if (this.isAdmin(channel, me)) {
-			$("#videoInfo").addClass("shown");
+            if (!watching) {
+                $('#videoInfo .link[data-action=viewVideo]').addClass('shown');
+            }
+        }
 
-			if (active) {
-				$("#videoInfo .link[data-action=startVideo]").removeClass("shown");
-				$("#videoInfo .link[data-action=endVideo]").addClass("shown");
+        if (this.isAdmin(channel, me)) {
+            $('#videoInfo').addClass('shown');
 
-				if (!joined) {
-					$("#videoInfo .link[data-action=joinVideo]").addClass("shown");
-				}
-			}
-			else {
-				$("#videoInfo .link[data-action=startVideo]").addClass("shown");
-			}
-		}
-		else if (speakers.includes(me.id)) {
-			$("#videoInfo").addClass("shown");
-			if (!joined) {
-				$("#videoInfo .link[data-action=joinVideo]").addClass("shown");
-			}
-		}
+            if (active) {
+                $('#videoInfo .link[data-action=startVideo]').removeClass(
+                    'shown'
+                );
+                $('#videoInfo .link[data-action=endVideo]').addClass('shown');
 
-		let done = new Promise(resolve => {
-			if (active) {
-				if (joined || watching) {
-					$("#videoInfo .link[data-action=leaveVideo]").addClass("shown");
+                if (!joined) {
+                    $('#videoInfo .link[data-action=joinVideo]').addClass(
+                        'shown'
+                    );
+                }
+            } else {
+                $('#videoInfo .link[data-action=startVideo]').addClass('shown');
+            }
+        } else if (speakers.includes(me.id)) {
+            $('#videoInfo').addClass('shown');
+            if (!joined) {
+                $('#videoInfo .link[data-action=joinVideo]').addClass('shown');
+            }
+        }
 
-					if (joined) {
-						$("#videoInfo .link[data-action=viewVideo]").removeClass("shown");
-					}
-				}
-			}
-			else {
-				$("#videoInfo .title").removeClass("shown");
-			}
+        let done = new Promise((resolve) => {
+            if (active) {
+                if (joined || watching) {
+                    $('#videoInfo .link[data-action=leaveVideo]').addClass(
+                        'shown'
+                    );
 
-			if (!watching && !joined) {
-				$("#videoContainer").removeClass("shown");
-			}
+                    if (joined) {
+                        $(
+                            '#videoInfo .link[data-action=viewVideo]'
+                        ).removeClass('shown');
+                    }
+                }
+            } else {
+                $('#videoInfo .title').removeClass('shown');
+            }
 
-			if (active && (joined || watching && users.length)) {
-				if (!$("#videoContainer").hasClass("shown")) {
-					$("#videoContainer").addClass("shown");
-					this.parent.stream.init().then(() => {
-						this.updateVideoUsers();
-						resolve();
-					});
-				}
-				else {
-					this.updateVideoUsers();
-					resolve();
-				}
-			}
-			else {
-				resolve();
-			}
-		});
-		return await done;
-	}
+            if (!watching && !joined) {
+                $('#videoContainer').removeClass('shown');
+            }
 
-	muteAll() {
-		this.setMute("toggleScreen", 1);
-		this.setMute("toggleAudio", 1);
-		this.setMute("toggleVideo", 1);
-	}
+            if (active && (joined || (watching && users.length))) {
+                if (!$('#videoContainer').hasClass('shown')) {
+                    $('#videoContainer').addClass('shown');
+                    this.parent.stream.init().then(() => {
+                        this.updateVideoUsers();
+                        resolve();
+                    });
+                } else {
+                    this.updateVideoUsers();
+                    resolve();
+                }
+            } else {
+                resolve();
+            }
+        });
+        return await done;
+    }
 
-	setMute(button, state) {
-		if (state == 1) {
-			$(`.controls .button[data-action=${button}]`).addClass("muted");
-		}
-		else if (state == 0) {
-			$(`.controls .button[data-action=${button}]`).removeClass("muted");
-		}
-		else {
-			$(`.controls .button[data-action=${button}]`).toggleClass("muted");
-		}
-	}
+    muteAll() {
+        this.setMute('toggleScreen', 1);
+        this.setMute('toggleAudio', 1);
+        this.setMute('toggleVideo', 1);
+    }
 
-	updateVideoUsers() {
-		let users = this.parent.currentVideoUsers();
+    setMute(button, state) {
+        if (state == 1) {
+            $(`.controls .button[data-action=${button}]`).addClass('muted');
+        } else if (state == 0) {
+            $(`.controls .button[data-action=${button}]`).removeClass('muted');
+        } else {
+            $(`.controls .button[data-action=${button}]`).toggleClass('muted');
+        }
+    }
 
-		$.each(Object.keys(users), (k, u) => {
-			this.parent.stream.addCam(u);
+    updateVideoUsers() {
+        let users = this.parent.currentVideoUsers();
 
-			let info = users[u];
-			if (info.video) {
-				$(`.cam[data-id=${u}]`).removeClass("videoMuted");
-			}
-			else {
-				$(`.cam[data-id=${u}]`).addClass("videoMuted");
-			}
+        $.each(Object.keys(users), (k, u) => {
+            this.parent.stream.addCam(u);
 
-			if (info.audio) {
-				$(`.cam[data-id=${u}]`).removeClass("audioMuted");
-			}
-			else {
-				$(`.cam[data-id=${u}]`).addClass("audioMuted");
-			}
-			
-			if (u == this.parent.domain && !this.parent.stream.sfu.webrtcStuff.myStream) {
-				this.parent.stream.register(this.parent.stream.sfu);
-				this.parent.stream.publish();
-			}
-		});
+            let info = users[u];
+            if (info.video) {
+                $(`.cam[data-id=${u}]`).removeClass('videoMuted');
+            } else {
+                $(`.cam[data-id=${u}]`).addClass('videoMuted');
+            }
 
-		$.each($(".cam"), (k, c) => {
-			let id = $(c).data("id");
-			if (!Object.keys(users).includes(id)) {
-				this.parent.stream.removeCam(id);
-			}
-		});
+            if (info.audio) {
+                $(`.cam[data-id=${u}]`).removeClass('audioMuted');
+            } else {
+                $(`.cam[data-id=${u}]`).addClass('audioMuted');
+            }
 
-		if (Object.keys(users).includes(this.parent.domain)) {
-			$("#videoContainer").addClass("publishing");
-		}
-		else {
-			$("#videoContainer").removeClass("publishing");
-		}
+            if (
+                u == this.parent.domain &&
+                !this.parent.stream.sfu.webrtcStuff.myStream
+            ) {
+                this.parent.stream.register(this.parent.stream.sfu);
+                this.parent.stream.publish();
+            }
+        });
 
-		this.parent.stream.dish.resize();
-		this.parent.stream.dish.resize();
-		this.parent.stream.dish.resize();
-	}
+        $.each($('.cam'), (k, c) => {
+            let id = $(c).data('id');
+            if (!Object.keys(users).includes(id)) {
+                this.parent.stream.removeCam(id);
+            }
+        });
+
+        if (Object.keys(users).includes(this.parent.domain)) {
+            $('#videoContainer').addClass('publishing');
+        } else {
+            $('#videoContainer').removeClass('publishing');
+        }
+
+        this.parent.stream.dish.resize();
+        this.parent.stream.dish.resize();
+        this.parent.stream.dish.resize();
+    }
 }

--- a/chat-server/create-channel.js
+++ b/chat-server/create-channel.js
@@ -1,0 +1,165 @@
+const readline = require('readline');
+const mysql = require('mysql');
+
+const config = require('./config.json');
+const { exit } = require('process');
+
+const sql = mysql.createPool({
+    host: config.sqlHost,
+    user: config.sqlUser,
+    password: config.sqlPass,
+    database: config.sqlDatabase,
+    port: config.sqlPort,
+    charset: 'utf8mb4',
+});
+
+const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+});
+
+async function db(query, values = []) {
+    let result = new Promise((resolve) => {
+        sql.query(query, values, (e, r, f) => {
+            try {
+                resolve(JSON.parse(JSON.stringify(r)));
+            } catch {
+                console.log(e);
+            }
+        });
+    });
+    return await result;
+}
+
+function time() {
+    return Math.floor(Date.now() / 1000);
+}
+
+function validName(name) {
+    try {
+        return name.match(
+            /^(?:[A-Za-z0-9][A-Za-z0-9\-]{0,61}[A-Za-z0-9]|[A-Za-z0-9])$/g
+        ).length;
+    } catch {}
+    return false;
+}
+
+const makeID = (length) => {
+    let text = '';
+    const possible =
+        'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+
+    for (let i = 0; i < length; i++) {
+        text += possible.charAt(Math.floor(Math.random() * possible.length));
+    }
+    return text;
+};
+
+async function generateID(type) {
+    var id, output;
+    var database, param, length, prefix;
+
+    switch (type) {
+        case 'session':
+            database = 'sessions';
+            param = 'id';
+            length = 32;
+            prefix = 'V2-';
+            break;
+
+        case 'domain':
+            database = 'domains';
+            param = 'id';
+            length = 16;
+            break;
+
+        case 'message':
+            database = 'messages';
+            param = 'id';
+            length = 32;
+            break;
+
+        case 'pm':
+            database = 'conversations';
+            param = 'id';
+            length = 16;
+            break;
+
+        case 'channel':
+            database = 'channels';
+            param = 'id';
+            length = 8;
+            break;
+
+        default:
+            return;
+    }
+
+    while (!output) {
+        id = makeID(length);
+        if (prefix) {
+            id = `${prefix}${id}`;
+        }
+
+        await db(`SELECT * FROM ${database} WHERE ${param} = ?`, [id]).then(
+            (r) => {
+                if (!r.length) {
+                    output = id;
+                }
+            }
+        );
+    }
+
+    return output;
+}
+
+rl.question('Enter channel name: ', async (channelName) => {
+    rl.question(
+        'Enter admin domains (comma separated): ',
+        async (adminNames) => {
+            if (!validName(channelName)) {
+                console.log(
+                    "Invalid channel name. A channel name can only contain letters, numbers, and hyphens, but can't start or end with a hyphen."
+                );
+                rl.close();
+                exit(1);
+            }
+
+            let id = await generateID('channel');
+            var adminNames = adminNames.split(',');
+
+            var admins = [];
+            for (var i = 0; i < adminNames.length; i++) {
+                let adminID = await db(
+                    'SELECT id FROM domains WHERE domain = ?',
+                    [adminNames[i].trim()]
+                );
+                if (!adminID.length) {
+                    console.log('Admin domain not found.');
+                    rl.close();
+                    exit(1);
+                }
+                admins.push(adminID[0].id);
+            }
+            admins = JSON.stringify(admins);
+            console.log(`Creating channel with admin IDs: ${admins}`);
+
+            let fee = `${config.channelPrice}.${
+                Math.floor(Math.random() * (999999 - 100000 + 1)) + 100000
+            }`;
+            let insert = await db(
+                'INSERT INTO channels (id, name, public, tldadmin, admins, fee, created, hidden, activated) VALUES (?,?,?,?,?,?,?,?,?)',
+                [id, channelName, true, false, admins, fee, time(), 0, 1]
+            );
+            if (!insert) {
+                console.log('Something went wrong. Try again.');
+                rl.close();
+                exit(1);
+            }
+
+            console.log(`Channel created successfully with ID: ${id}`);
+            rl.close();
+            exit(0);
+        }
+    );
+});


### PR DESCRIPTION
**Motivation**

Just linking to hns-chat isn’t enough; we need to link to hns-chat with the correct seller channel already open, and with a relevant order id (if applicable) already referenced.

---

**Changes**

Support these querystring keys in the link: 

user={user name} should open a direct private chat with the user, if that user exists.

channel={channel name} should open the channel directly

order={order id} if this is passed, the text, and if ‘user’ key is passed, then when the private chat is opened with the user, “Order ID: <order id>” should appear in the message draft.


Note that these should work even if the user has to create a username first. For example: 
- user follows link that has “user=some-store&order=123”
- user is blocked by the “Add domain”/”create user” screen 
- user adds the domain 
- user continues through to the hns-chat site

a private chat opens automatically to user “some-store” with “Order ID: 123” in the message.